### PR TITLE
 Add .proto files of the binary representations used in CEL.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,10 @@
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-3.5.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
+)
+http_archive(
+    name = "com_google_protobuf_javalite",
+    strip_prefix = "protobuf-javalite",
+    urls = ["https://github.com/google/protobuf/archive/javalite.zip"],
+)

--- a/proto/checked/README
+++ b/proto/checked/README
@@ -1,0 +1,4 @@
+# Protocol Buffer Definitions
+
+These directories contain the .proto files defining the binary representations
+used by CEL language tools.

--- a/proto/checked/v1/BUILD
+++ b/proto/checked/v1/BUILD
@@ -24,7 +24,7 @@ proto_library(
     ],
 )
 
-go_proto_library(
+proto_library( # IGNORE go_proto_library
     name = "checked_go_proto",
     deps = [":checked_protos"],
 )
@@ -39,7 +39,7 @@ java_lite_proto_library(
     deps = [":checked_protos"],
 )
 
-jspb_proto_library(
+proto_library( # IGNORE jspb_proto_library
     name = "checked_jspb_proto",
     deps = [":checked_protos"],
 )

--- a/proto/checked/v1/BUILD
+++ b/proto/checked/v1/BUILD
@@ -1,0 +1,45 @@
+package(
+    # default_compatible_with = ["//buildenv/target:appengine"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+proto_library(
+    name = "checked_protos",
+    srcs = [
+        "checked.proto",
+    ],
+    # cc_api_version = 2,
+    # go_api_version = 2,
+    # java_api_version = 2,
+    # js_api_version = 2,
+    deps = [
+        "//proto/v1:syntax_protos",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+go_proto_library(
+    name = "checked_go_proto",
+    deps = [":checked_protos"],
+)
+
+java_proto_library(
+    name = "checked_java_proto",
+    deps = [":checked_protos"],
+)
+
+java_lite_proto_library(
+    name = "checked_java_proto_lite",
+    deps = [":checked_protos"],
+)
+
+jspb_proto_library(
+    name = "checked_jspb_proto",
+    deps = [":checked_protos"],
+)

--- a/proto/checked/v1/LICENSE
+++ b/proto/checked/v1/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/proto/checked/v1/checked.proto
+++ b/proto/checked/v1/checked.proto
@@ -1,0 +1,305 @@
+syntax = "proto3";
+
+// Protos for representing CEL declarations and typed checked expressions.
+package google.api.expr.checked.v1;
+
+option cc_enable_arenas = true;
+option java_multiple_files = true;
+option java_outer_classname = "CheckedProto";
+option java_package = "com.google.api.expr.checked.v1";
+
+import "proto/v1/syntax.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+// A CEL expression which has been successfully type checked.
+message CheckedExpr {
+  reserved 1;
+
+  // A map from expression ids to resolved references.
+  //
+  // The following entries are in this table:
+  //
+  // - An Ident or Select expression is represented here if it resolves to a
+  //   declaration. For instance, if `a.b.c` is represented by
+  //   `select(select(id(a), b), c)`, and `a.b` resolves to a declaration,
+  //   while `c` is a field selection, then the reference is attached to the
+  //   nested select expression (but not to the id or or the outer select).
+  //   In turn, if `a` resolves to a declaration and `b.c` are field selections,
+  //   the reference is attached to the ident expression.
+  // - Every Call expression has an entry here, identifying the function being
+  //   called.
+  // - Every CreateStruct expression for a message has an entry, identifying
+  //   the message.
+  map<int64, Reference> reference_map = 2;
+
+  // A map from expression ids to types.
+  //
+  // Every expression node which has a type different than DYN has a mapping
+  // here. If an expression has type DYN, it is omitted from this map to save
+  // space.
+  map<int64, Type> type_map = 3;
+
+  // The source info derived from input that generated the parsed `expr` and
+  // any optimizations made during the type-checking pass.
+  google.api.expr.v1.SourceInfo source_info = 5;
+
+  // The checked expression. Semantically equivalent to the parsed `expr`, but
+  // may have structural differences.
+  google.api.expr.v1.Expr expr = 4;
+}
+
+// Represents a CEL type.
+message Type {
+  // CEL primitive types.
+  enum PrimitiveType {
+    // Unspecified type.
+    PRIMITIVE_TYPE_UNSPECIFIED = 0;
+
+    // Boolean type.
+    BOOL = 1;
+
+    // Int64 type.
+    //
+    // Proto-based integer values are widened to int64.
+    INT64 = 2;
+
+    // Uint64 type.
+    //
+    // Proto-based unsigned integer values are widened to uint64.
+    UINT64 = 3;
+
+    // Double type.
+    //
+    // Proto-based float values are widened to double values.
+    DOUBLE = 4;
+
+    // String type.
+    STRING = 5;
+
+    // Bytes type.
+    BYTES = 6;
+  }
+
+  // Well-known protobuf types treated with first-class support in CEL.
+  enum WellKnownType {
+    // Unspecified type.
+    WELL_KNOWN_TYPE_UNSPECIFIED = 0;
+
+    // Well-known protobuf.Any type.
+    //
+    // Any types are a polymorphic message type. During type-checking they are
+    // treated like `DYN` types, but at runtime they are resolved to a specific
+    // message type specified at evaluation time.
+    ANY = 1;
+
+    // Well-known protobuf.Timestamp type, internally referenced as `timestamp`.
+    TIMESTAMP = 2;
+
+    // Well-known protobuf.Duration type, internally referenced as `duration`.
+    DURATION = 3;
+  }
+
+  // List type with typed elements, e.g. `list<example.proto.MyMessage>`.
+  message ListType {
+    Type elem_type = 1;
+  }
+
+  // Map type with parameterized key and value types, e.g. `map<string, int>`.
+  message MapType {
+    // The type of the key.
+    Type key_type = 1;
+
+    // The type of the value.
+    Type value_type = 2;
+  }
+
+  // Function type with result and arg types.
+  message FunctionType {
+    // Result type of the function.
+    Type result_type = 1;
+
+    // Argument types of the function.
+    repeated Type arg_types = 2;
+  }
+
+  // The kind of type.
+  oneof type_kind {
+    // Dynamic type.
+    protobuf.Empty dyn = 1;
+
+    // Null value.
+    protobuf.NullValue null = 2;
+
+    // Primitive types: `true`, `1u`, `-2.0`, `'string'`, `b'bytes'`.
+    PrimitiveType primitive = 3;
+
+    // Wrapper of a primitive type, e.g. `google.protobuf.Int64Value`.
+    PrimitiveType wrapper = 4;
+
+    // Well-known protobuf type such as `google.protobuf.Timestamp`.
+    WellKnownType well_known = 5;
+
+    // Parameterized list with elements of `list_type`, e.g. `list<timestamp>`.
+    ListType list_type = 6;
+
+    // Parameterized map with typed keys and values.
+    MapType map_type = 7;
+
+    // Function type.
+    FunctionType function = 8;
+
+    // Protocol buffer message type.
+    //
+    // The `message_type` string specifies the qualified message type name. For
+    // example, `google.plus.Profile`.
+    string message_type = 9;
+
+    // Type param type.
+    //
+    // The `type_param` string specifies the type parameter name, e.g. `list<E>`
+    // would be a `list_type` whose element type was a `type_param` type
+    // named `E`.
+    string type_param = 10;
+
+    // Type type.
+    //
+    // The `type` value specifies the target type. e.g. int is type with a
+    // target type of `Primitive.INT`.
+    Type type = 11;
+
+    // Error type.
+    //
+    // During type-checking if an expression is an error, its type is propagated
+    // as the `ERROR` type. This permits the type-checker to discover other
+    // errors present in the expression.
+    protobuf.Empty error = 12;
+
+    // Extension type, used for extending the type-checking with additional
+    // types which are well-known for a particular application of CEL.
+    protobuf.Any extension = 13;
+  }
+}
+
+// Represents a declaration of a named value or function.
+//
+// A declaration is part of the contract between the expression, the agent
+// evaluating that expression, and the caller requesting evaluation.
+message Decl {
+  // Identifier declaration which specifies its type and optional `Expr` value.
+  //
+  // An identifier without a value is a declaration that must be provided at
+  // evaluation time. An identifier with a value should resolve to a constant,
+  // but may be used in conjunction with other identifiers bound at evaluation
+  // time.
+  message IdentDecl {
+    // Required. The type of the identifier.
+    Type type = 1;
+
+    // The constant value of the identifier. If not specified, the identifier
+    // must be supplied at evaluation time.
+    google.api.expr.v1.Constant value = 2;
+
+    // Documentation string for the identifier.
+    string doc = 3;
+  }
+
+  // Function declaration specifies one or more overloads which indicate the
+  // function's parameter types and return type, and may optionally specify a
+  // function definition in terms of CEL expressions.
+  //
+  // Functions have no observable side-effects (there may be side-effects like
+  // logging which are not observable from CEL).
+  message FunctionDecl {
+    // An overload indicates a function's parameter types and return type, and
+    // may optionally include a function body described in terms of [Expr][]
+    // values.
+    //
+    // Functions overloads are declared in either a function or method
+    // call-style. For methods, the `params[0]` is the expected type of the
+    // target receiver.
+    //
+    // Overloads must have non-overlapping argument types after erasure of all
+    // parameterized type variables (similar as type erasure in Java).
+    message Overload {
+      // Required. Globally unique overload name of the function which reflects
+      // the function name and argument types.
+      //
+      // This will be used by a [Reference][] to indicate the `overload_id` that
+      // was resolved for the function `name`.
+      string overload_id = 1;
+
+      // List of function parameter [Type][] values.
+      //
+      // Param types are disjoint after generic type parameters have been
+      // replaced with the type `DYN`. Since the `DYN` type is compatible with
+      // any other type, this means that if `A` is a type parameter, the
+      // function types `int<A>` and `int<int>` are not disjoint. Likewise,
+      // `map<string, string>` is not disjoint from `map<K, V>`.
+      //
+      // When the `result_type` of a function is a generic type param, the
+      // type param name also appears as the `type` of on at least one params.
+      repeated Type params = 2;
+
+      // The type param names associated with the function declaration.
+      //
+      // For example, `function ex<K,V>(K key, map<K, V> map) : V` would yield
+      // the type params of `K, V`.
+      repeated string type_params = 3;
+
+      // Required. The result type of the function. For example, the operator
+      // `string.isEmpty()` would have `result_type` of `kind: BOOL`.
+      Type result_type = 4;
+
+      // Whether the function is to be used in a method call-style `x.f(...)`
+      // of a function call-style `f(x, ...)`.
+      //
+      // For methods, the first parameter declaration, `params[0]` is the
+      // expected type of the target receiver.
+      bool is_instance_function = 5;
+
+      // Documentation string for the overload.
+      string doc = 6;
+    }
+
+    // Required. List of function overloads, must contain at least one overload.
+    repeated Overload overloads = 1;
+  }
+
+  // The fully qualified name of the declaration.
+  //
+  // Declarations are organized in containers and this represents the full path
+  // to the declaration in its container, as in `google.api.expr.Decl`.
+  //
+  // Declarations used as [FunctionDecl.Overload][] parameters may or may not
+  // have a name depending on whether the overload is function declaration or a
+  // function definition containing a result [Expr][].
+  string name = 1;
+
+  // Required. The declaration kind.
+  oneof decl_kind {
+    IdentDecl ident = 2;        // Identifier declaration.
+    FunctionDecl function = 3;  // Function declaration.
+  }
+}
+
+// Describes a resolved reference to a declaration.
+message Reference {
+  // The fully qualified name of the declaration.
+  string name = 1;
+
+  // For references to functions, this is a list of `Overload.overload_id`
+  // values which match according to typing rules.
+  //
+  // If the list has more than one element, overload resolution among the
+  // presented candidates must happen at runtime because of dynamic types. The
+  // type checker attempts to narrow down this list as much as possible.
+  //
+  // Empty for [Decl.IdentDecl][] references.
+  repeated string overload_id = 3;
+
+  // For references to constants, this may contain the value of the
+  // constant if known at compile time.
+  google.api.expr.v1.Constant value = 4;
+}

--- a/proto/v1/BUILD
+++ b/proto/v1/BUILD
@@ -25,7 +25,7 @@ proto_library(
     ],
 )
 
-go_proto_library(
+proto_library( # IGNORE go_proto_library)
     name = "value_go_proto",
     deps = [":value_protos"],
 )
@@ -40,7 +40,7 @@ java_lite_proto_library(
     deps = [":value_protos"],
 )
 
-jspb_proto_library(
+proto_library( # IGNORE jspbb_proto_library)
     name = "value_jspb_proto",
     deps = [":value_protos"],
 )
@@ -63,12 +63,12 @@ proto_library(
     ],
 )
 
-go_proto_library(
+proto_library( # IGNORE go_proto_library)
     name = "syntax_go_proto",
     deps = [":syntax_protos"],
 )
 
-py_proto_library(
+proto_library( # IGNORE py_proto_library)
     name = "syntax_py_pb2",
     # api_version = 2,
     deps = [":syntax_protos"],
@@ -84,7 +84,7 @@ java_lite_proto_library(
     deps = [":syntax_protos"],
 )
 
-jspb_proto_library(
+proto_library( # IGNORE jspbb_proto_library)
     name = "syntax_jspb_proto",
     deps = [":syntax_protos"],
 )

--- a/proto/v1/BUILD
+++ b/proto/v1/BUILD
@@ -1,0 +1,90 @@
+package(
+    # default_compatible_with = ["//buildenv/target:appengine"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+proto_library(
+    name = "value_protos",
+    srcs = [
+        "value.proto",
+    ],
+    # cc_api_version = 2,
+    # go_api_version = 2,
+    # java_api_version = 2,
+    # js_api_version = 2,
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+go_proto_library(
+    name = "value_go_proto",
+    deps = [":value_protos"],
+)
+
+java_proto_library(
+    name = "value_java_proto",
+    deps = [":value_protos"],
+)
+
+java_lite_proto_library(
+    name = "value_java_proto_lite",
+    deps = [":value_protos"],
+)
+
+jspb_proto_library(
+    name = "value_jspb_proto",
+    deps = [":value_protos"],
+)
+
+proto_library(
+    name = "syntax_protos",
+    srcs = [
+        "syntax.proto",
+    ],
+    # cc_api_version = 2,
+    # go_api_version = 2,
+    # java_api_version = 2,
+    # js_api_version = 2,
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+go_proto_library(
+    name = "syntax_go_proto",
+    deps = [":syntax_protos"],
+)
+
+py_proto_library(
+    name = "syntax_py_pb2",
+    # api_version = 2,
+    deps = [":syntax_protos"],
+)
+
+java_proto_library(
+    name = "syntax_java_proto",
+    deps = [":syntax_protos"],
+)
+
+java_lite_proto_library(
+    name = "syntax_java_proto_lite",
+    deps = [":syntax_protos"],
+)
+
+jspb_proto_library(
+    name = "syntax_jspb_proto",
+    deps = [":syntax_protos"],
+)

--- a/proto/v1/LICENSE
+++ b/proto/v1/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/proto/v1/syntax.proto
+++ b/proto/v1/syntax.proto
@@ -1,0 +1,266 @@
+syntax = "proto3";
+
+package google.api.expr.v1;
+
+option cc_enable_arenas = true;
+option java_multiple_files = true;
+option java_outer_classname = "SyntaxProto";
+option java_package = "com.google.api.expr.v1";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+// A representation of the abstract syntax of the Common Expression Language.
+
+// An expression together with source information as returned by the parser.
+message ParsedExpr {
+  reserved 1;
+
+  // The parsed expression.
+  Expr expr = 2;
+
+  // The source info derived from input that generated the parsed `expr`.
+  SourceInfo source_info = 3;
+}
+
+// An abstract representation of a common expression.
+//
+// Expressions are abstractly represented as a collection of identifiers,
+// select statements, function calls, literals, and comprehensions. All
+// operators with the exception of the '.' operator are modelled as function
+// calls. This makes it easy to represent new operators into the existing AST.
+//
+// All references within expressions must resolve to a [Decl][] provided at
+// type-check for an expression to be valid. A reference may either be a bare
+// identifier `name` or a qualified identifier `google.api.name`. References
+// may either refer to a value or a function declaration.
+//
+// For example, the expression `google.api.name.startsWith('expr')` references
+// the declaration `google.api.name` within a [Expr.Select][] expression, and
+// the function declaration `startsWith`.
+message Expr {
+  // An identifier expression. e.g. `request`.
+  message Ident {
+    // Required. Holds a single, unqualified identifier, possibly preceded by a
+    // '.'.
+    //
+    // Qualified names are represented by the [Expr.Select][] expression.
+    string name = 1;
+  }
+
+  // A field selection expression. e.g. `request.auth`.
+  message Select {
+    // Required. The target of the selection expression.
+    //
+    // For example, in the select expression `request.auth`, the `request`
+    // portion of the expression is the `operand`.
+    Expr operand = 1;
+
+    // Required. The name of the field to select.
+    //
+    // For example, in the select expression `request.auth`, the `auth` portion
+    // of the expression would be the `field`.
+    string field = 2;
+
+    // Whether the select is to be interpreted as a field presence test.
+    //
+    // This results from the macro `has(request.auth)`.
+    bool test_only = 3;
+  }
+
+  // A call expression, including calls to predefined functions and operators.
+  //
+  // For example, `value == 10`, `size(map_value)`.
+  message Call {
+    // The target of an method call-style expression. For example, `x` in
+    // `x.f()`.
+    Expr target = 1;
+
+    // Required. The name of the function or method being called.
+    string function = 2;
+
+    // The arguments.
+    repeated Expr args = 3;
+  }
+
+  // A list creation expression.
+  //
+  // Lists may either be homogenous, e.g. `[1, 2, 3]`, or heterogenous, e.g.
+  // `dyn([1, 'hello', 2.0])`
+  message CreateList {
+    // The elements part of the list.
+    repeated Expr elements = 1;
+  }
+
+  // A map or message creation expression.
+  //
+  // Maps are constructed as `{'key_name': 'value'}`. Message construction is
+  // similar, but prefixed with a type name and composed of field ids:
+  // `types.MyType{field_id: 'value'}`.
+  message CreateStruct {
+    // Represents an entry.
+    message Entry {
+      // Required. An id assigned to this node by the parser which is unique
+      // in a given expression tree. This is used to associate type
+      // information and other attributes to the node.
+      int64 id = 1;
+
+      // The `Entry` key kinds.
+      oneof key_kind {
+        // The field key for a message creator statement.
+        string field_key = 2;
+
+        // The key expression for a map creation statement.
+        Expr map_key = 3;
+      }
+
+      // Required. The value assigned to the key.
+      Expr value = 4;
+    }
+
+    // The type name of the message to be created, empty when creating map
+    // literals.
+    string message_name = 1;
+
+    // The entries in the creation expression.
+    repeated Entry entries = 2;
+  }
+
+  // A comprehension expression applied to a list or map.
+  //
+  // Comprehensions are not part of the core syntax, but enabled with macros.
+  // A macro matches a specific call signature within a parsed AST and replaces
+  // the call with an alternate AST block. Macro expansion happens at parse
+  // time.
+  //
+  // The following macros are supported within CEL:
+  //
+  // Aggregate type macros may be applied to all elements in a list or all keys
+  // in a map:
+  //
+  // *  `all`, `exists`, `exists_one` -  test a predicate expression against
+  //    the inputs and return `true` if the predicate is satisfied for all,
+  //    any, or only one value `list.all(x, x < 10)`.
+  // *  `filter` - test a predicate expression against the inputs and return
+  //    the subset of elements which satisfy the predicate:
+  //    `payments.filter(p, p > 1000)`.
+  // *  `map` - apply an expression to all elements in the input and return the
+  //    output aggregate type: `[1, 2, 3].map(i, i * i)`.
+  //
+  // The `has(m.x)` macro tests whether the property `x` is present in struct
+  // `m`. The semantics of this macro depend on the type of `m`. For proto2
+  // messages `has(m.x)` is defined as 'defined, but not set`. For proto3, the
+  // macro tests whether the property is set to its default. For map and struct
+  // types, the macro tests whether the property `x` is defined on `m`.
+  message Comprehension {
+    // The name of the iteration variable.
+    string iter_var = 1;
+
+    // The range over which var iterates.
+    Expr iter_range = 2;
+
+    // The name of the variable used for accumulation of the result.
+    string accu_var = 3;
+
+    // The initial value of the accumulator.
+    Expr accu_init = 4;
+
+    // An expression which can contain iter_var and accu_var.
+    //
+    // Returns false when the result has been computed and may be used as
+    // a hint to short-circuit the remainder of the comprehension.
+    Expr loop_condition = 5;
+
+    // An expression which can contain iter_var and accu_var.
+    //
+    // Computes the next value of accu_var.
+    Expr loop_step = 6;
+
+    // An expression which can contain accu_var.
+    //
+    // Computes the result.
+    Expr result = 7;
+  }
+
+  reserved 1;
+
+  // Required. An id assigned to this node by the parser which is unique in a
+  // given expression tree. This is used to associate type information and other
+  // attributes to a node in the parse tree.
+  int64 id = 2;
+
+  // Required. Variants of expressions.
+  oneof expr_kind {
+    // A constant expression.
+    Constant const_expr = 3;
+
+    // An identifier expression.
+    Ident ident_expr = 4;
+
+    // A field selection expression, e.g. `request.auth`.
+    Select select_expr = 5;
+
+    // A call expression, including calls to predefined functions and operators.
+    Call call_expr = 6;
+
+    // A list creation expression.
+    CreateList list_expr = 7;
+
+    // A map or message creation expression.
+    CreateStruct struct_expr = 8;
+
+    // A comprehension expression.
+    Comprehension comprehension_expr = 9;
+  }
+}
+
+// Represents a primitive literal.
+//
+// This is similar as the primitives supported in the well-known type
+// `google.protobuf.Value`, but richer so it can represent CEL's full range of
+// primitives.
+//
+// Lists and structs are not included as constants as these aggregate types may
+// contain [Expr][] elements which require evaluation and are thus not constant.
+//
+// Examples of constants include: `"hello"`, `b'bytes'`, `1u`, `4.2`, `-2`,
+// `true`, `null`.
+message Constant {
+  // Required. The valid constant kinds.
+  oneof constant_kind {
+    protobuf.NullValue null_value = 1;       // null value.
+    bool bool_value = 2;                     // boolean value.
+    int64 int64_value = 3;                   // int64 value.
+    uint64 uint64_value = 4;                 // uint64 value.
+    double double_value = 5;                 // double value.
+    string string_value = 6;                 // string value.
+    bytes bytes_value = 7;                   // bytes value.
+    protobuf.Duration duration_value = 8;    // protobuf.Duration value.
+    protobuf.Timestamp timestamp_value = 9;  // protobuf.Timestamp value.
+  }
+}
+
+// Source information collected at parse time.
+message SourceInfo {
+  // The syntax version of the source, e.g. `cel1`.
+  string syntax_version = 1;
+
+  // The location name. All position information attached to an expression is
+  // relative to this location.
+  //
+  // The location could be a file, UI element, or similar. For example,
+  // `acme/app/AnvilPolicy.cel`.
+  string location = 2;
+
+  // Monotonically increasing list of character offsets where newlines appear.
+  //
+  // The line number of a given position is the index `i` where for a given
+  // `id` the `line_offsets[i] < id_positions[id] < line_offsets[i+1]`. The
+  // column may be derivd from `id_positions[id] - line_offsets[i]`.
+  repeated int32 line_offsets = 3;
+
+  // A map from the parse node id (e.g. `Expr.id`) to the character offset
+  // within source.
+  map<int64, int32> positions = 4;
+}

--- a/proto/v1/value.proto
+++ b/proto/v1/value.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+// Contains representations for CEL runtime values.
+package google.api.expr.v1;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "ValueProto";
+option java_package = "com.google.api.expr.v1";
+
+option cc_enable_arenas = true;
+
+// Represents a CEL value.
+//
+// This is similar to `google.protobuf.Value`, but can represent CEL's full
+// range of values.
+message Value {
+  // Required. The valid kinds of values.
+  oneof kind {
+    // Null value.
+    google.protobuf.NullValue null_value = 1;
+
+    // Boolean value.
+    bool bool_value = 2;
+
+    // Numeric values.
+    int64 int64_value = 3;
+    uint64 uint64_value = 4;
+    double double_value = 5;
+
+    // String values.
+    string string_value = 6;
+    bytes bytes_value = 7;
+
+    // Well known type values.
+    protobuf.Duration duration_value = 8;
+    protobuf.Timestamp timestamp_value = 9;
+
+    // Proto message value.
+    protobuf.Any message_value = 10;
+
+    // Collection values.
+    MapValue map_value = 11;
+    ListValue list_value = 12;
+  }
+}
+
+// A list.
+message ListValue {
+  // The ordered values in the list.
+  repeated Value values = 1;
+}
+
+// A map.
+message MapValue {
+  message Entry {
+    // The key.
+    //
+    // Must be unique with in the map.
+    // Currently only boolean, int, uint, and string values can be keys.
+    Value key = 1;
+
+    // The value.
+    Value value = 2;
+  }
+
+  // The set of map entries.
+  repeated Entry entries = 1;
+}


### PR DESCRIPTION
First commit is the main Copybara export.
Second commit is a minor fixup of a Copybara problem that was generating invalid Bazel BUILD files.