### PR TITLE
Remove reference to Angular project.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Contributor Code of Conduct
-## Version 0.1 (adapted from 0.3b-angular)
+## Version 0.1.1 (adapted from 0.3b-angular)
 
 As contributors and maintainers of the Common Expression Language
 (CEL) project, we pledge to respect everyone who contributes by
@@ -14,7 +14,7 @@ insults, or other unprofessional conduct.
 We promise to extend courtesy and respect to everyone involved in this
 project regardless of gender, gender identity, sexual orientation,
 disability, age, race, ethnicity, religion, or level of experience. We
-expect anyone contributing to the Angular project to do the same.
+expect anyone contributing to the project to do the same.
 
 If any member of the community violates this code of conduct, the
 maintainers of the CEL project may take action, removing issues,


### PR DESCRIPTION
The reference to the Angular project had been erroneously left in when the CoC was adapted from Angular's CoC.