### PR TITLE
Introduce go_proto_library Bazel BUILD targets

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "cel_spec")
+
 http_archive(
     name = "com_google_protobuf",
     strip_prefix = "protobuf-3.5.0",
@@ -8,3 +10,11 @@ http_archive(
     strip_prefix = "protobuf-javalite",
     urls = ["https://github.com/google/protobuf/archive/javalite.zip"],
 )
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
+    sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()

--- a/proto/checked/v1/BUILD
+++ b/proto/checked/v1/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
 package(
     # default_compatible_with = ["//buildenv/target:appengine"],
     default_visibility = ["//visibility:public"],
@@ -21,6 +23,15 @@ proto_library(
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:empty_proto",
         "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+go_proto_library(
+    name = "checked_go_proto",
+    importpath = "github.com/google/cel-spec/proto/checked/v1",
+    proto = ":checked_protos",
+    deps = [
+        "//proto/v1:syntax_go_proto",
     ],
 )
 

--- a/proto/v1/BUILD
+++ b/proto/v1/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
 package(
     # default_compatible_with = ["//buildenv/target:appengine"],
     default_visibility = ["//visibility:public"],
@@ -23,6 +25,12 @@ proto_library(
         "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
+)
+
+go_proto_library(
+    name = "value_go_proto",
+    proto = ":value_protos",
+    importpath = "github.com/google/cel-spec/proto/v1",
 )
 
 java_proto_library(
@@ -51,6 +59,12 @@ proto_library(
         "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
+)
+
+go_proto_library(
+    name = "syntax_go_proto",
+    proto = ":syntax_protos",
+    importpath = "github.com/google/cel-spec/proto/v1",
 )
 
 java_proto_library(


### PR DESCRIPTION
This change introduces Bazel BUILD targets for generating Go code from protos.

Note, this is a retry of a previous pull request from a proper fork.