### PR TITLE
Suggestion: Become a subset of ECMAScript

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -97,3 +97,4 @@ fully type checked at compile time.
 
 [1]: https://en.wikipedia.org/wiki/Protocol_Buffers
 [2]: https://developers.google.com/protocol-buffers/docs/proto3
+


### PR DESCRIPTION
I'm sorry, this is just feedback, since the Issues feature is disabled I created a dummy PR instead to put this.

I was looking for a cross-language expression language and CEL seems to be a great match.

I noticed that it borrows some JavaScript/ECMAScript-like syntax but not always. For example: `Account{name: "Eamonn"}`.

I was wondering if CEL's syntax can be a subset of ECMAScript, while remaining specific to its restricted use case of expression language. For example, `Account{name: "Eamonn"}` may become `new Account({name: "Eamonn"})` which would be a valid ES syntax, while (I think) not making it harder for CEL parser.

A nice benefit is that any ECMAScript parser can be used to parse CEL, even if not explicitly supported. For example I'm looking for an EL that is implemented in Python, and either @Kronuz's https://github.com/Kronuz/esprima-python or @jeffkistler's https://github.com/jeffkistler/BigRig would work well here, even if `cel-python` is not yet developed.

BTW I submitted a Wikipedia article on CEL: https://en.wikipedia.org/wiki/Common_Expression_Language

Thank you!