### PR TITLE
conformance-tests: basic "==" and lookup tests

### DIFF
--- a/tests/simple/testdata/basic.textproto
+++ b/tests/simple/testdata/basic.textproto
@@ -132,6 +132,32 @@ section {
 section {
   name: "variables"
   description: "Variable lookups."
+  test {
+    name: "self_eval_bound_lookup"
+    expr: "x"
+    type_env: {
+      name: "x",
+      ident: { type: { primitive: INT64 } }
+    }
+    bindings: {
+      key: "x",
+      value: { value: { int64_value: 123 } }
+    }
+    value: { int64_value: 123 }
+  }
+  test {
+    name: "self_eval_container_lookup"
+    expr: "x.y"
+    value: { bool_value: true }
+    type_env: {
+      name: "x.y",
+      ident: { type: { primitive: BOOL } }
+    }
+    bindings: {
+      key: "x.y",
+      value: { value: { bool_value: true } }
+    }
+  }
 }
 section {
   name: "namespace"

--- a/tests/simple/testdata/broken.textproto
+++ b/tests/simple/testdata/broken.textproto
@@ -1,0 +1,42 @@
+name: "broken"
+description:
+  "Conformance tests that are not currently working on at least one of the standard implementations."
+  "Each section here will be named with filename.textproto/sectionname, to know where it should go once fixed."
+section {
+  name: "basic.textproto/variables"
+  test {
+    name: "self_eval_unbound_lookup"
+    description: "An unbound variable should be marked as an error during execution. {BugID TBD}"
+    expr: "x"
+    disable_check: true
+    ## Expected behavior
+    eval_error: {
+      errors: { message: "undeclared reference to 'x' (in container '')" }
+    }
+    ## Current behavior as expressed by the cel-go implementation
+    #unknown: {
+    #  exprs: 1
+    #}
+  }
+}
+section {
+  name: "comparisons.textproto/Literal Comparison"
+  test {
+    name: "self_test_equals_mixed_types"
+    description: "A mix of types fails during type checks but can't be captured in the conformance tests yet {BugID TBD}. Also, if you disable checks it yields {bool_value: false} where it should also yield an error"
+    expr: "1.0 == 1"
+    disable_check: true # need to make it fail in the evaluation phase
+    eval_error : {
+      errors: { message: "found no matching overload for '_==_' applied to '(double, int)'" }
+    }
+  }
+  test {
+    name: "self_test_not_equals_data_type"
+    description: "A mix of types in a list fails during type checks. See #self_test_equals_mixed_types"
+    expr: "[1] == [1.0]"
+    disable_check: true # need to make it fail in the evaluation phase
+    eval_error: {
+      errors: { message: "found no matching overload for '_==_' applied to '(list(int), list(double))'" }
+    }
+  }
+}

--- a/tests/simple/testdata/broken.textproto
+++ b/tests/simple/testdata/broken.textproto
@@ -6,7 +6,7 @@ section {
   name: "basic.textproto/variables"
   test {
     name: "self_eval_unbound_lookup"
-    description: "An unbound variable should be marked as an error during execution. {BugID TBD}"
+    description: "An unbound variable should be marked as an error during execution. See google/cel-go#154"
     expr: "x"
     disable_check: true
     ## Expected behavior
@@ -23,7 +23,7 @@ section {
   name: "comparisons.textproto/Literal Comparison"
   test {
     name: "self_test_equals_mixed_types"
-    description: "A mix of types fails during type checks but can't be captured in the conformance tests yet {BugID TBD}. Also, if you disable checks it yields {bool_value: false} where it should also yield an error"
+    description: "A mix of types fails during type checks but can't be captured in the conformance tests yet (See google/cel-go#155). Also, if you disable checks it yields {bool_value: false} where it should also yield an error"
     expr: "1.0 == 1"
     disable_check: true # need to make it fail in the evaluation phase
     eval_error : {

--- a/tests/simple/testdata/broken.textproto
+++ b/tests/simple/testdata/broken.textproto
@@ -36,7 +36,8 @@ section {
     expr: "[1] == [1.0]"
     disable_check: true # need to make it fail in the evaluation phase
     eval_error: {
-      errors: { message: "found no matching overload for '_==_' applied to '(list(int), list(double))'" }
+      # Note: The type checker error shows (list(int), list(double)) instead
+      errors: { message: "found no matching overload for '_==_' applied to '(list, list)'" }
     }
   }
 }

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -1,8 +1,8 @@
 name: "comparisons"
 description: "Tests for boolean-valued functions and operators."
 section {
-  name: "Literal comparison"
-  description: "Comparing literals (no bindings)"
+  name: "Literal comparison for _==_"
+  description: "Comparing literals for equality"
   test {
     name: "self_test_equals_int64"
     expr: "1 == 1"
@@ -45,8 +45,13 @@ section {
   }
   test {
     name: "self_test_equals_string_raw"
-    expr: "'a' == r'a'"
+    expr: "'abc' == r'abc'"
     value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_case"
+    expr: "'abc' == 'ABC'"
+    value: { bool_value: false }
   }
   test {
     name: "self_test_equals_null"
@@ -120,10 +125,19 @@ section {
     value: { bool_value: false }
   }
   test {
+    name: "self_test_equals_map_keyorder"
+    expr: "{'k1':'v1','k2':'v2'} == {'k2':'v2','k1':'v1'}"
+    value: { bool_value: true }
+  }
+  test {
     name: "self_test_not_equals_map_key_casing"
     expr: "{'key':'value'} == {'Key':'value'}"
     value: { bool_value: false }
   }
+}
+section {
+  name: "Literal comparison for _!=_"
+  description: "Comparing literals for inequality"
 }
 section {
   name: "Bound comparison"

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -1,2 +1,131 @@
 name: "comparisons"
 description: "Tests for boolean-valued functions and operators."
+section {
+  name: "Literal comparison"
+  description: "Comparing literals (no bindings)"
+  test {
+    name: "self_test_equals_int64"
+    expr: "1 == 1"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_int64"
+    expr: "-1 == 1"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_equals_uint64"
+    expr: "2u == 2u"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_uint64"
+    expr: "1u == 2u"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_equals_double"
+    expr: "1.0 == 1.0e+0"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_double"
+    expr: "-1.0 == 1.0"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_equals_string"
+    expr: "'' == \"\""
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_string"
+    expr: "'a' == 'b'"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_equals_string_raw"
+    expr: "'a' == r'a'"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_equals_null"
+    expr: "null == null"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_equals_bool"
+    expr: "true == true"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_bool"
+    expr: "false == true"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_equals_byte"
+    description: "Test bytes literal equality with encoding"
+    expr: "b'\\u00FF' == b'\303\277'"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_byte"
+    expr: "b'abc' == b'abcd'"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_equals_list_empty"
+    expr: "[] == []"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_equals_list_numbers"
+    expr: "[1, 2, 3] == [1, 2, 3]"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_list_order"
+    expr: "[1, 2, 3] == [1, 3, 2]"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_not_equals_list_string_case"
+    expr: "['case'] == ['cAse']"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_equals_map_empty"
+    expr: "{} == {}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_equals_map_onekey"
+    expr: "{'k':'v'} == {\"k\":\"v\"}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_equals_map_floatvalue"
+    expr: "{'k':1.0} == {'k':1e+0}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_equals_map_value"
+    expr: "{'k':'v'} == {'k':'v1'}"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_not_equals_map_extrakey"
+    expr: "{'k':'v','k1':'v1'} == {'k':'v'}"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_not_equals_map_key_casing"
+    expr: "{'key':'value'} == {'Key':'value'}"
+    value: { bool_value: false }
+  }
+}
+section {
+  name: "Bound comparison"
+  description: "Comparing bound variables with literals or other variables"
+}


### PR DESCRIPTION
Adding basic equality and lookup tests:

- _==_ tests for int/uint/double/string/null/bool/byte/list/map.
- Basic lookup tests.
- `broken.textproto` for the issues reported (google/cel-go#154 and google/cel-go#155)
