### PR TITLE
conformance: Add tests for _!=_

### DIFF
--- a/tests/simple/testdata/basic.textproto
+++ b/tests/simple/testdata/basic.textproto
@@ -14,12 +14,12 @@ section {
     value: { uint64_value: 0 }
   }
   test {
-    name: "self_eval_double_zero"
+    name: "self_eval_float_zero"
     expr: "0.0"
     value: { double_value: 0 }
   }
   test {
-    name: "self_eval_double_zerowithexp"
+    name: "self_eval_float_zerowithexp"
     expr: "0e+0"
     value: { double_value: 0 }
   }
@@ -39,7 +39,7 @@ section {
     value: { string_value: "" }
   }
   test {
-    name: "self_eval_byte_empty"
+    name: "self_eval_bytes_empty"
     expr: 'b""'
     value: { bytes_value: "" }
   }
@@ -69,8 +69,8 @@ section {
   description: "Simple self-evaluating forms to non-zero-ish values."
   test {
     name: "self_eval_int_nonzero"
-    expr: "17"
-    value: { int64_value: 17 }
+    expr: "42"
+    value: { int64_value: 42 }
   }
   test {
     name: "self_eval_uint_nonzero"
@@ -83,7 +83,7 @@ section {
     value: { int64_value: -9223372036854775808 }
   }
   test {
-    name: "self_eval_double_negative_exp"
+    name: "self_eval_float_negative_exp"
     expr: "-2.3e+1"
     value: { double_value: -23.0 }
   }
@@ -98,7 +98,7 @@ section {
     value: { string_value: "'" }
   }
   test {
-    name: "self_eval_binary_escape"
+    name: "self_eval_bytes_escape"
     expr: "b'\\u00FF'"
     value: { bytes_value: "\303\277" }
   }

--- a/tests/simple/testdata/broken.textproto
+++ b/tests/simple/testdata/broken.textproto
@@ -20,6 +20,26 @@ section {
   }
 }
 section {
+  name: "basic.textproto/self_eval_nonzeroish"
+  test {
+    name: "self_eval_map_twoitems"
+    description: "Map literals should be order independent for the checker. google/cel-go#156"
+    expr: '{"k1":"v1","k":"v"}'
+    value: {
+      map_value {
+        entries {
+          key: { string_value: "k" }
+          value: { string_value: "v" }
+        }
+        entries {
+          key: { string_value: "k1" }
+          value: { string_value: "v1" }
+        }
+      }
+    }
+  }
+}
+section {
   name: "comparisons.textproto/Literal Comparison"
   test {
     name: "self_test_equals_mixed_types"

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -220,6 +220,11 @@ section {
     value: { bool_value: true }
   }
   test {
+    name: "self_test_not_ne_list_bool"
+    expr: "[false, true] != [false, true]"
+    value: { bool_value: false }
+  }
+  test {
     name: "self_test_not_ne_list_of_list"
     expr: "[[]] != [[]]"
     value: { bool_value: false }

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -24,12 +24,12 @@ section {
     value: { bool_value: false }
   }
   test {
-    name: "self_test_equals_double"
+    name: "self_test_equals_float"
     expr: "1.0 == 1.0e+0"
     value: { bool_value: true }
   }
   test {
-    name: "self_test_not_equals_double"
+    name: "self_test_not_equals_float"
     expr: "-1.0 == 1.0"
     value: { bool_value: false }
   }
@@ -138,6 +138,112 @@ section {
 section {
   name: "Literal comparison for _!=_"
   description: "Comparing literals for inequality"
+  test {
+    name: "self_test_ne_int64"
+    expr: "24 != 42"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_int64"
+    expr: "1 != 1"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_uint64"
+    expr: "1u != 2u"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_uint64"
+    expr: "99u != 99u"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_float"
+    expr: "9.0e+3 != 9001.0"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_float"
+    expr: "1.0 != 1e+0"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_string"
+    expr: "'abc' != ''"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_string"
+    expr: "'abc' != 'abc'"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_bytes"
+    expr: "b'\\x00\\xFF' != b'\\u00FF'"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_bytes"
+    expr: "b'\303\277' != b'\\u00FF'"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_bool"
+    expr: "false != true"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_bool"
+    expr: "true != true"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_not_ne_null"
+    description: "null can only be equal to null, or else it won't match"
+    expr: "null != null"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_list_empty"
+    expr: "[] != [1]"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_list_empty"
+    expr: "[] != []"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_list_bool"
+    expr: "[true, false, true] != [true, true, false]"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_list_of_list"
+    expr: "[[]] != [[]]"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_ne_map_by_value"
+    expr: "{'k':'v'} != {'k':'v1'}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_ne_map_by_key"
+    expr: "{'k':true} != {'k1':true}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "self_test_not_ne_map_int_to_float"
+    expr: "{1:1.0} != {1:1.0}"
+    value: { bool_value: false }
+  }
+  test {
+    name: "self_test_not_ne_map_key_order"
+    expr: "{'a':'b','c':'d'} != {'c':'d','a':'b'}"
+    value: { bool_value: false }
+  }
 }
 section {
   name: "Bound comparison"


### PR DESCRIPTION
Add tests for the `_!=_` operand on `int/uint/float/string/bool/null/bytes/list/map`.

Bonus track: Fixing some of the original test names' to utilize the correct naming for floating point numbers.