### PR TITLE
Move fixed tests into their appropriate locations.

### DIFF
--- a/tests/simple/testdata/broken.textproto
+++ b/tests/simple/testdata/broken.textproto
@@ -66,28 +66,6 @@ section {
   }
 }
 section {
-  name: "comparisons.textproto/Literal Comparison"
-  test {
-    name: "self_test_equals_mixed_types"
-    description: "A mix of types fails during type checks but can't be captured in the conformance tests yet (See google/cel-go#155). Also, if you disable checks it yields {bool_value: false} where it should also yield an error"
-    expr: "1.0 == 1"
-    disable_check: true # need to make it fail in the evaluation phase
-    eval_error : {
-      errors: { message: "found no matching overload for '_==_' applied to '(double, int)'" }
-    }
-  }
-  test {
-    name: "self_test_not_equals_data_type"
-    description: "A mix of types in a list fails during type checks. See #self_test_equals_mixed_types"
-    expr: "[1] == [1.0]"
-    disable_check: true # need to make it fail in the evaluation phase
-    eval_error: {
-      # Note: The type checker error shows (list(int), list(double)) instead
-      errors: { message: "found no matching overload for '_==_' applied to '(list, list)'" }
-    }
-  }
-}
-section {
   name: "fields.textproto/fields"
   test {
     name: "map_key_float"
@@ -120,45 +98,6 @@ section {
     ## Expected behavior: Failed with repeated key.
     ## Current behavior:
     value: { int64_value: 1 }
-  }
-  test {
-    name: "ident_with_longest_prefix_check"
-    description: "namespace resolution should try to find the longest prefix for the checker."
-    expr: "a.b.c"
-    type_env: {
-      name: "a.b.c",
-      ident: { type: { primitive: STRING } }
-    }
-    bindings: {
-      key: "a.b.c",
-      value: { value: { string_value: "yeah" } }
-    }
-    type_env: {
-      name: "a.b",
-      ident: {
-        type: {
-          map_type: {
-            key_type: {primitive: STRING}
-            value_type: {primitive: STRING}
-          }
-        }
-      }
-    }
-    bindings: {
-      key: "a.b"
-      value: {
-        value: {
-          map_value: {
-            entries {
-              key: { string_value: "c" }
-              value: { string_value: "oops" }
-            }
-          }
-        }
-      }
-    }
-    ## Expected behavior: "yeah"
-    value: { string_value: "oops" }
   }
   test {
     name: "ident_with_longest_prefix_eval"

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -135,7 +135,7 @@ section {
     value: { bool_value: false }
   }
   test {
-    name: "self_test_equals_mixed_types"
+    name: "not_eq_mixed_types"
     description: "A mix of types fails during type checks but can't be captured in the conformance tests yet (See google/cel-go#155). Also, if you disable checks it yields {bool_value: false} where it should also yield an error"
     expr: "1.0 == 1"
     disable_check: true # need to make it fail in the evaluation phase
@@ -144,12 +144,11 @@ section {
     }
   }
   test {
-    name: "self_test_not_equals_data_type"
+    name: "not_eq_list_data_types"
     description: "A mix of types in a list fails during type checks. See #self_test_equals_mixed_types"
     expr: "[1] == [1.0]"
     disable_check: true # need to make it fail in the evaluation phase
     eval_error: {
-      # Note: The type checker error shows (list(int), list(double)) instead
       errors: { message: "found no matching overload for '_==_' applied to '(list, list)'" }
     }
   }

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -134,6 +134,25 @@ section {
     expr: "{'key':'value'} == {'Key':'value'}"
     value: { bool_value: false }
   }
+  test {
+    name: "self_test_equals_mixed_types"
+    description: "A mix of types fails during type checks but can't be captured in the conformance tests yet (See google/cel-go#155). Also, if you disable checks it yields {bool_value: false} where it should also yield an error"
+    expr: "1.0 == 1"
+    disable_check: true # need to make it fail in the evaluation phase
+    eval_error : {
+      errors: { message: "found no matching overload for '_==_' applied to '(double, int)'" }
+    }
+  }
+  test {
+    name: "self_test_not_equals_data_type"
+    description: "A mix of types in a list fails during type checks. See #self_test_equals_mixed_types"
+    expr: "[1] == [1.0]"
+    disable_check: true # need to make it fail in the evaluation phase
+    eval_error: {
+      # Note: The type checker error shows (list(int), list(double)) instead
+      errors: { message: "found no matching overload for '_==_' applied to '(list, list)'" }
+    }
+  }
 }
 section {
   name: "ne_literal"

--- a/tests/simple/testdata/fields.textproto
+++ b/tests/simple/testdata/fields.textproto
@@ -265,4 +265,42 @@ section {
       }
     }
   }
+  test {
+    name: "ident_with_longest_prefix_check"
+    description: "namespace resolution should try to find the longest prefix for the checker."
+    expr: "a.b.c"
+    type_env: {
+      name: "a.b.c",
+      ident: { type: { primitive: STRING } }
+    }
+    bindings: {
+      key: "a.b.c",
+      value: { value: { string_value: "yeah" } }
+    }
+    type_env: {
+      name: "a.b",
+      ident: {
+        type: {
+          map_type: {
+            key_type: {primitive: STRING}
+            value_type: {primitive: STRING}
+          }
+        }
+      }
+    }
+    bindings: {
+      key: "a.b"
+      value: {
+        value: {
+          map_value: {
+            entries {
+              key: { string_value: "c" }
+              value: { string_value: "oops" }
+            }
+          }
+        }
+      }
+    }
+    value: { string_value: "yeah" }
+  }
 }


### PR DESCRIPTION
Move fixed tests out of `broken.textproto` and into their rightful homes.