### PR TITLE
In and equality tests

### DIFF
--- a/tests/simple/testdata/broken.textproto
+++ b/tests/simple/testdata/broken.textproto
@@ -67,6 +67,23 @@ section {
   }
 }
 section {
+  name: "comparisons.textproto/in_map_literal"
+  test {
+    name: "key_in_mixed_key_type_map_error"
+    expr: "'em' in {1u:'el', 2:b'em'}"
+    # Current behavior
+    value: { bool_value: false }
+    # This case is very hard to detect in implementations for a variety of
+    # reasons. However, it is only necessary when there are strict requirements
+    # for homogeneous equality.
+    #
+    # Expected behavior:
+    # eval_error: {
+    #  errors: { message: "no such overload" }
+    # }
+  }
+}
+section {
   name: "fields.textproto/fields"
   test {
     name: "map_key_float"

--- a/tests/simple/testdata/broken.textproto
+++ b/tests/simple/testdata/broken.textproto
@@ -70,7 +70,7 @@ section {
   name: "comparisons.textproto/in_map_literal"
   test {
     name: "key_in_mixed_key_type_map_error"
-    expr: "'em' in {1u:'el', 2:b'em'}"
+    expr: "'key' in {1u:'str', 2:b'bytes'}"
     # Current behavior
     value: { bool_value: false }
     # This case is very hard to detect in implementations for a variety of

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -140,7 +140,7 @@ section {
     expr: "1.0 == 1"
     disable_check: true # need to make it fail in the evaluation phase
     eval_error : {
-      errors: { message: "found no matching overload for '_==_' applied to '(double, int)'" }
+      errors: { message: "no such overload" }
     }
   }
   test {
@@ -149,15 +149,15 @@ section {
     expr: "[1] == [1.0]"
     disable_check: true # need to make it fail in the evaluation phase
     eval_error: {
-      errors: { message: "found no matching overload for '_==_' applied to '(list, list)'" }
+      errors: { message: "no such overload" }
     }
   }
   test {
     name: "eq_map_value_mixed_types_error"
-    description: "Mixed map key value types should result in an error due to homogeneous equality restrictions"
-    expr: "{'k':'v', 1:1} == {1:'v1', 'k':'v'}"
+    description: "Mixed map value types yields error as key '1' values differed by type."
+    expr: "{'k':'v', 1:1} == {'k':'v', 1:'v1'}"
     eval_error: {
-      errors: { message: "found no matching overload for '_==_' applied to '(map, map)'" }
+      errors: { message: "no such overload" }
     }
   }
 }
@@ -756,22 +756,24 @@ section {
   }
   test {
     name: "elem_in_list"
-    expr: "'elem' in ['elem', 'el', 'em']"
+    expr: "'elem' in ['elem', 'elemA', 'elemB']"
     value { bool_value: true }
   }
   test {
     name: "elem_not_in_list"
-    expr: "'e' in ['elem', 'el', 'em']"
+    expr: "'not' in ['elem1', 'elem2', 'elem3']"
     value { bool_value: false }
   }
   test {
     name: "elem_in_mixed_type_list"
-    expr: "'el' in [1, 'el', 2]"
+        description: "List elems are of mixed type, and since the elem is absent the result is error."
+    expr: "'elem' in [1, 'elem', 2]"
     value { bool_value: true }
   }
   test {
     name: "elem_in_mixed_type_list_error"
-    expr: "'em' in [1u, 'el', 2, b'em']"
+    description: "List elems are of mixed type, and since the elem is absent the result is error."
+    expr: "'elem' in [1u, 'str', 2, b'bytes']"
     eval_error: {
       errors: { message: "no such overload" }
     }
@@ -787,17 +789,18 @@ section {
   }
   test {
     name: "key_in_map"
-    expr: "'elem' in {'elem':'el', 'em':'no'}"
+    expr: "'key' in {'key':'1', 'other':'2'}"
     value { bool_value: true }
   }
   test {
     name: "key_not_in_map"
-    expr: "'e' in {'f':1, 'g':2}"
+    expr: "'key' in {'lock':1, 'gate':2}"
     value { bool_value: false }
   }
   test {
     name: "key_in_mixed_key_type_map"
-    expr: "'el' in {'el':2u, 3:3.0}"
+    description: "Map keys are of mixed type, but since the key is present the result is true."
+    expr: "'key' in {3:3.0, 'key':2u}"
     value { bool_value: true }
   }
 }

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -747,6 +747,61 @@ section {
   }
 }
 section {
+  name: "in_list_literal"
+  description: "Set membership tests using list literals and the 'in' operator"
+  test {
+    name: "elem_not_in_empty_list"
+    expr: "'empty' in []"
+    value { bool_value: false }
+  }
+  test {
+    name: "elem_in_list"
+    expr: "'elem' in ['elem', 'el', 'em']"
+    value { bool_value: true }
+  }
+  test {
+    name: "elem_not_in_list"
+    expr: "'e' in ['elem', 'el', 'em']"
+    value { bool_value: false }
+  }
+  test {
+    name: "elem_in_mixed_type_list"
+    expr: "'el' in [1, 'el', 2]"
+    value { bool_value: true }
+  }
+  test {
+    name: "elem_in_mixed_type_list_error"
+    expr: "'em' in [1u, 'el', 2, b'em']"
+    eval_error: {
+      errors: { message: "no such overload" }
+    }
+  }
+}
+section {
+  name: "in_map_literal"
+  description: "Set membership tests using map literals and the 'in' operator"
+  test {
+    name: "key_not_in_empty_map"
+    expr: "'empty' in {}"
+    value { bool_value: false }
+  }
+  test {
+    name: "key_in_map"
+    expr: "'elem' in {'elem':'el', 'em':'no'}"
+    value { bool_value: true }
+  }
+  test {
+    name: "key_not_in_map"
+    expr: "'e' in {'f':1, 'g':2}"
+    value { bool_value: false }
+  }
+  test {
+    name: "key_in_mixed_key_type_map"
+    expr: "'el' in {'el':2u, 3:3.0}"
+    value { bool_value: true }
+  }
+}
+section {
   name: "bound"
   description: "Comparing bound variables with literals or other variables"
   test {

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -135,7 +135,7 @@ section {
     value: { bool_value: false }
   }
   test {
-    name: "not_eq_mixed_types"
+    name: "eq_mixed_types_error"
     description: "A mix of types fails during type checks but can't be captured in the conformance tests yet (See google/cel-go#155). Also, if you disable checks it yields {bool_value: false} where it should also yield an error"
     expr: "1.0 == 1"
     disable_check: true # need to make it fail in the evaluation phase
@@ -144,12 +144,20 @@ section {
     }
   }
   test {
-    name: "not_eq_list_data_types"
+    name: "eq_list_elem_mixed_types_error"
     description: "A mix of types in a list fails during type checks. See #self_test_equals_mixed_types"
     expr: "[1] == [1.0]"
     disable_check: true # need to make it fail in the evaluation phase
     eval_error: {
       errors: { message: "found no matching overload for '_==_' applied to '(list, list)'" }
+    }
+  }
+  test {
+    name: "eq_map_value_mixed_types_error"
+    description: "Mixed map key value types should result in an error due to homogeneous equality restrictions"
+    expr: "{'k':'v', 1:1} == {1:'v1', 'k':'v'}"
+    eval_error: {
+      errors: { message: "found no matching overload for '_==_' applied to '(map, map)'" }
     }
   }
 }

--- a/tests/simple/testdata/macros.textproto
+++ b/tests/simple/testdata/macros.textproto
@@ -29,24 +29,24 @@ section {
   }
   test {
     name: "map_key_exists"
-    expr: "{'a':1, 'b':2}.exists(k, k == 'b')"
+    expr: "{'key1':1, 'key2':2}.exists(k, k == 'key2')"
     value: { bool_value: true }
   }
   test {
     name: "not_map_key_exists"
-    expr: "!{'a':1, 'b':2}.exists(k, k == 'c')"
+    expr: "!{'key1':1, 'key2':2}.exists(k, k == 'key3')"
     value: { bool_value: true }
   }
   test {
     name: "map_key_mixed_type_exists"
     description: "Exists filter is true for the second key, thus reduces to 'err || true' which is true"
-    expr: "{'a':1, 1:21}.exists(k, k != 2)"
+    expr: "{'key':1, 1:21}.exists(k, k != 2)"
     value: { bool_value: true }
   }
   test {
     name: "map_key_mixed_type_exists_error"
     description: "Exists filter is never true, thus reduces to 'err || false' which is an error" 
-    expr: "!{'a':1, 1:42}.exists(k, k == 2)"
+    expr: "!{'key':1, 1:42}.exists(k, k == 2)"
     eval_error: {
       errors: { message: "no such overload" }
     }

--- a/tests/simple/testdata/macros.textproto
+++ b/tests/simple/testdata/macros.textproto
@@ -14,10 +14,37 @@ section {
     value: { bool_value: true }
   }
   test {
-    name: "list_elem_exists_error"
+    name: "list_elem_mixed_type_exists"
+    expr: "[1, '2', 3].exists(e, e != '3')"
+    value: { bool_value: true }
+  }
+  test {
+    name: "list_elem_mixed_type_exists_error"
     expr: "[1, '2', 3].exists(e, e == '3')"
     eval_error: {
-      errors: { message: "found no matching overload for '_==_' applied to '(map, map)'" }
+      errors: { message: "no such overload" }
+    }
+  }
+  test {
+    name: "map_key_exists"
+    expr: "{'a':1, 'b':2}.exists(k, k == 'b')"
+    value: { bool_value: true }
+  }
+  test {
+    name: "not_map_key_exists"
+    expr: "!{'a':1, 'b':2}.exists(k, k == 'c')"
+    value: { bool_value: true }
+  }
+  test {
+    name: "map_key_mixed_type_exists"
+    expr: "!{'a':1, 1:2}.exists(k, k != 2)"
+    value: { bool_value: false }
+  }
+  test {
+    name: "map_key_mixed_type_exists_error"
+    expr: "!{'a':1, 1:2}.exists(k, k == 2)"
+    eval_error: {
+      errors: { message: "no such overload" }
     }
   }
 }

--- a/tests/simple/testdata/macros.textproto
+++ b/tests/simple/testdata/macros.textproto
@@ -15,12 +15,14 @@ section {
   }
   test {
     name: "list_elem_mixed_type_exists"
-    expr: "[1, '2', 3].exists(e, e != '3')"
+    description: "Exists filter is true for the second element, thus short-circuits after 'err || true'"
+    expr: "[1, '2', 3].exists(e, e != '10')"
     value: { bool_value: true }
   }
   test {
     name: "list_elem_mixed_type_exists_error"
-    expr: "[1, '2', 3].exists(e, e == '3')"
+    description: "Exists filter is never true, thus reduces to 'err || false || err' which is an error"
+    expr: "[1, '2', 3].exists(e, e == '10')"
     eval_error: {
       errors: { message: "no such overload" }
     }
@@ -37,12 +39,14 @@ section {
   }
   test {
     name: "map_key_mixed_type_exists"
-    expr: "!{'a':1, 1:2}.exists(k, k != 2)"
-    value: { bool_value: false }
+    description: "Exists filter is true for the second key, thus reduces to 'err || true' which is true"
+    expr: "{'a':1, 1:21}.exists(k, k != 2)"
+    value: { bool_value: true }
   }
   test {
     name: "map_key_mixed_type_exists_error"
-    expr: "!{'a':1, 1:2}.exists(k, k == 2)"
+    description: "Exists filter is never true, thus reduces to 'err || false' which is an error" 
+    expr: "!{'a':1, 1:42}.exists(k, k == 2)"
     eval_error: {
       errors: { message: "no such overload" }
     }

--- a/tests/simple/testdata/macros.textproto
+++ b/tests/simple/testdata/macros.textproto
@@ -1,2 +1,23 @@
 name: "macros"
 description: "Tests for CEL macros."
+section {
+  name: "exists"
+  description: "Checks for the existence of a map key or list element"
+  test {
+    name: "list_elem_exists"
+    expr: "[1, 2, 3].exists(e, e == 2)"
+    value: { bool_value: true }
+  }
+  test {
+    name: "not_list_elem_exists"
+    expr: "![1, 2, 3].exists(e, e > 3)"
+    value: { bool_value: true }
+  }
+  test {
+    name: "list_elem_exists_error"
+    expr: "[1, '2', 3].exists(e, e == '3')"
+    eval_error: {
+      errors: { message: "found no matching overload for '_==_' applied to '(map, map)'" }
+    }
+  }
+}


### PR DESCRIPTION
Add conformance tests for the `in` operator, the `exists` macro, and an additional map equality test.

Also, note a broken case on the current cel-go implementation for a very unlikely map configuration which is permissible given the spec. 