### PR TITLE
Byte and string literals match Google SQL.

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -232,19 +232,27 @@ multiline string literals can be used for byte literals.
 
 Escape sequences are a backslash (`\`) followed by one of the following:
 
-*   A single-quote(`'`), double-quote(`"`), or backslash(`\`), representing
-    itself.
+*   A punctuation mark representing itself:
+    *   `\`: backslash
+    *   `?`: question mark
+    *   `"`: double quote
+    *   `'`: single quote
+    *   `` ` ``: backtick
 *   A code for whitespace:
+    *   `a`: bell
     *   `b`: backspace
     *   `f`: form feed
     *   `n`: line feed
     *   `r`: carriage return
     *   `t`: horizontal tab
+    *   `v`: vertical tab
 *   A `u` followed by four hexadecimal characters, encoding a Unicode code point
     in the BMP. Characters in other Unicode planes can be represented with
-    surrogate pairs.
-*   A `x` followed by two hexadecimal characters. For strings, it denotes the
-    unicode code point. For bytes, it represents an octet value.
+    surrogate pairs.  Valid only for string literals.
+*   A `U` followed by eight hexadecimal characters, encoding a Unicode code
+    point.  Valid only for string literals.
+*   A `x` or `X` followed by two hexadecimal characters. For strings, it
+    denotes the unicode code point. For bytes, it represents an octet value.
 *   Three octal digits, in the range `000` to `377`. For strings, it denotes the
     unicode code point. For bytes, it represents an octet value.
 

--- a/tests/simple/testdata/basic.textproto
+++ b/tests/simple/testdata/basic.textproto
@@ -99,7 +99,7 @@ section {
   }
   test {
     name: "self_eval_bytes_escape"
-    expr: "b'\\u00FF'"
+    expr: "b'ÿ'"
     value: { bytes_value: "\303\277" }
   }
   test {

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -71,7 +71,7 @@ section {
   test {
     name: "eq_bytes"
     description: "Test bytes literal equality with encoding"
-    expr: "b'\\u00FF' == b'\303\277'"
+    expr: "b'ÿ' == b'\\303\\277'"
     value: { bool_value: true }
   }
   test {
@@ -206,12 +206,12 @@ section {
   }
   test {
     name: "ne_bytes"
-    expr: "b'\\x00\\xFF' != b'\\u00FF'"
+    expr: "b'\\x00\\xFF' != b'ÿ'"
     value: { bool_value: true }
   }
   test {
     name: "not_ne_bytes"
-    expr: "b'\303\277' != b'\\u00FF'"
+    expr: "b'\\303\\277' != b'ÿ'"
     value: { bool_value: false }
   }
   test {
@@ -363,7 +363,7 @@ section {
   }
   test {
     name: "not_lt_bytes_width"
-    expr: "b'\u00E1' < b'b'"
+    expr: "b'á' < b'b'"
     value: { bool_value: false }
   }
   test {


### PR DESCRIPTION
Remove unicode escapes in byte literals in conformance tests.