### PR TITLE
Add dashboard documentation to cel-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ For more detail, see:
 *   [Introduction](doc/intro.md)
 *   [Language Definition](doc/langdef.md)
 
+A dashboard that shows results of conformance tests on current CEL
+implementations can be found
+[here](https://k8s-testgrid.appspot.com/google-cel).
+
 Released under the [Apache License](LICENSE).
 
 Disclaimer: This is not an official Google product.


### PR DESCRIPTION
Add link to CEL conformance dashboard and instructions on how to create additional dashboards.