### PR TITLE
Proto support for conformance tests

### DIFF
--- a/proto/test/v1/proto2/BUILD.bazel
+++ b/proto/test/v1/proto2/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+proto_library(
+    name = "test_all_types_proto",
+    srcs = [ "test_all_types.proto" ],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "test_all_types_cc_proto",
+    deps = [":test_all_types_proto",],
+)
+
+go_proto_library(
+    name = "test_all_types_go_proto",
+    proto = ":test_all_types_proto",
+    importpath = "github.com/google/cel-spec/proto/test/v1/proto2/test_all_types",
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
+        "@io_bazel_rules_go//proto/wkt:struct_go_proto",
+        "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+    ],
+)

--- a/proto/test/v1/proto2/test_all_types.proto
+++ b/proto/test/v1/proto2/test_all_types.proto
@@ -59,8 +59,8 @@ message TestAllTypes {
 
   // Nested messages
   oneof nested_type {
-    NestedMessage single_nested_message = 18;
-    NestedEnum single_nested_enum = 21 [default = BAR];
+    NestedMessage single_nested_message = 21;
+    NestedEnum single_nested_enum = 22 [default = BAR];
   }
 
   // Repeated
@@ -80,18 +80,16 @@ message TestAllTypes {
   repeated string repeated_string = 44;
   repeated bytes repeated_bytes = 45;
 
-  repeated NestedMessage repeated_nested_message = 48;
-
-  repeated NestedEnum repeated_nested_enum = 51;
-
-  repeated string repeated_string_piece = 54 [ctype = STRING_PIECE];
-  repeated string repeated_cord = 55 [ctype = CORD];
-
-  repeated NestedMessage repeated_lazy_message = 57 [lazy = true];
+  // Repeated and nested
+  repeated NestedMessage repeated_nested_message = 51;
+  repeated NestedEnum repeated_nested_enum = 52;
+  repeated string repeated_string_piece = 53 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 54 [ctype = CORD];
+  repeated NestedMessage repeated_lazy_message = 55 [lazy = true];
 
   // Map
-  map<string, string> map_string_string = 58;
-  map<int64, NestedTestAllTypes> map_int64_nested_type = 59;
+  map<string, string> map_string_string = 61;
+  map<int64, NestedTestAllTypes> map_int64_nested_type = 62;
 }
 
 // This proto includes a recursively nested message.

--- a/proto/test/v1/proto2/test_all_types.proto
+++ b/proto/test/v1/proto2/test_all_types.proto
@@ -1,0 +1,108 @@
+syntax = "proto2";
+
+package google.api.expr.test.v1.proto2;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+// This proto includes every type of field in both singular and repeated
+// forms.
+message TestAllTypes {
+  message NestedMessage {
+    // The field name "b" fails to compile in proto1 because it conflicts with
+    // a local variable named "b" in one of the generated methods.
+    // This file needs to compile in proto1 to test backwards-compatibility.
+    optional int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  // Singular
+  optional int32 single_int32 = 1 [default = -32];
+  optional int64 single_int64 = 2 [default = -64];
+  optional uint32 single_uint32 = 3 [default = 32];
+  optional uint64 single_uint64 = 4 [default = 64];
+  optional sint32 single_sint32 = 5;
+  optional sint64 single_sint64 = 6;
+  optional fixed32 single_fixed32 = 7;
+  optional fixed64 single_fixed64 = 8;
+  optional sfixed32 single_sfixed32 = 9;
+  optional sfixed64 single_sfixed64 = 10;
+  optional float single_float = 11 [default = 3.0];
+  optional double single_double = 12 [default = 6.4];
+  optional bool single_bool = 13 [default = true];
+  optional string single_string = 14 [default = "empty"];
+  optional bytes single_bytes = 15 [default = "none"];
+
+  // Wellknown.
+  optional google.protobuf.Any single_any = 100;
+  optional google.protobuf.Duration single_duration = 101;
+  optional google.protobuf.Timestamp single_timestamp = 102;
+  optional google.protobuf.Struct single_struct = 103;
+  optional google.protobuf.Value single_value = 104;
+  optional google.protobuf.Int64Value single_int64_wrapper = 105;
+  optional google.protobuf.Int32Value single_int32_wrapper = 106;
+  optional google.protobuf.DoubleValue single_double_wrapper = 107;
+  optional google.protobuf.FloatValue single_float_wrapper = 108;
+  optional google.protobuf.UInt64Value single_uint64_wrapper = 109;
+  optional google.protobuf.UInt32Value single_uint32_wrapper = 110;
+  optional google.protobuf.StringValue single_string_wrapper = 111;
+  optional google.protobuf.BoolValue single_bool_wrapper = 112;
+  optional google.protobuf.BytesValue single_bytes_wrapper = 113;
+
+  // Nested messages
+  oneof nested_type {
+    NestedMessage single_nested_message = 18;
+    NestedEnum single_nested_enum = 21 [default = BAR];
+  }
+
+  // Repeated
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+
+  repeated NestedMessage repeated_nested_message = 48;
+
+  repeated NestedEnum repeated_nested_enum = 51;
+
+  repeated string repeated_string_piece = 54 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 55 [ctype = CORD];
+
+  repeated NestedMessage repeated_lazy_message = 57 [lazy = true];
+
+  // Map
+  map<string, string> map_string_string = 58;
+  map<int64, NestedTestAllTypes> map_int64_nested_type = 59;
+}
+
+// This proto includes a recursively nested message.
+message NestedTestAllTypes {
+  optional NestedTestAllTypes child = 1;
+  optional TestAllTypes payload = 2;
+}
+
+// This proto tests that global enums are resolved correctly.
+enum GlobalEnum {
+  GOO = 0;
+  GAR = 1;
+  GAZ = 2;
+}

--- a/proto/test/v1/proto3/BUILD.bazel
+++ b/proto/test/v1/proto3/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+proto_library(
+    name = "test_all_types_proto",
+    srcs = [ "test_all_types.proto" ],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "test_all_types_cc_proto",
+    deps = [":test_all_types_proto",],
+)
+
+go_proto_library(
+    name = "test_all_types_go_proto",
+    proto = ":test_all_types_proto",
+    importpath = "github.com/google/cel-spec/proto/test/v1/proto3/test_all_types",
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
+        "@io_bazel_rules_go//proto/wkt:struct_go_proto",
+        "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+    ],
+)

--- a/proto/test/v1/proto3/test_all_types.proto
+++ b/proto/test/v1/proto3/test_all_types.proto
@@ -1,0 +1,108 @@
+syntax = "proto3";
+
+package google.api.expr.test.v1.proto3;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+// This proto includes every type of field in both singular and repeated
+// forms.
+message TestAllTypes {
+  message NestedMessage {
+    // The field name "b" fails to compile in proto1 because it conflicts with
+    // a local variable named "b" in one of the generated methods.
+    // This file needs to compile in proto1 to test backwards-compatibility.
+    int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  // Singular
+  int32 single_int32 = 1;
+  int64 single_int64 = 2;
+  uint32 single_uint32 = 3;
+  uint64 single_uint64 = 4;
+  sint32 single_sint32 = 5;
+  sint64 single_sint64 = 6;
+  fixed32 single_fixed32 = 7;
+  fixed64 single_fixed64 = 8;
+  sfixed32 single_sfixed32 = 9;
+  sfixed64 single_sfixed64 = 10;
+  float single_float = 11;
+  double single_double = 12;
+  bool single_bool = 13;
+  string single_string = 14;
+  bytes single_bytes = 15;
+
+  // Wellknown.
+  google.protobuf.Any single_any = 100;
+  google.protobuf.Duration single_duration = 101;
+  google.protobuf.Timestamp single_timestamp = 102;
+  google.protobuf.Struct single_struct = 103;
+  google.protobuf.Value single_value = 104;
+  google.protobuf.Int64Value single_int64_wrapper = 105;
+  google.protobuf.Int32Value single_int32_wrapper = 106;
+  google.protobuf.DoubleValue single_double_wrapper = 107;
+  google.protobuf.FloatValue single_float_wrapper = 108;
+  google.protobuf.UInt64Value single_uint64_wrapper = 109;
+  google.protobuf.UInt32Value single_uint32_wrapper = 110;
+  google.protobuf.StringValue single_string_wrapper = 111;
+  google.protobuf.BoolValue single_bool_wrapper = 112;
+  google.protobuf.BytesValue single_bytes_wrapper = 113;
+
+  // Nested messages
+  oneof nested_type {
+    NestedMessage single_nested_message = 18;
+    NestedEnum single_nested_enum = 21;
+  }
+
+  // Repeated
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+
+  repeated NestedMessage repeated_nested_message = 48;
+
+  repeated NestedEnum repeated_nested_enum = 51;
+
+  repeated string repeated_string_piece = 54 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 55 [ctype = CORD];
+
+  repeated NestedMessage repeated_lazy_message = 57 [lazy = true];
+
+  // Map
+  map<string, string> map_string_string = 58;
+  map<int64, NestedTestAllTypes> map_int64_nested_type = 59;
+}
+
+// This proto includes a recursively nested message.
+message NestedTestAllTypes {
+  NestedTestAllTypes child = 1;
+  TestAllTypes payload = 2;
+}
+
+// This proto tests that global enums are resolved correctly.
+enum GlobalEnum {
+  GOO = 0;
+  GAR = 1;
+  GAZ = 2;
+}

--- a/proto/test/v1/proto3/test_all_types.proto
+++ b/proto/test/v1/proto3/test_all_types.proto
@@ -59,8 +59,8 @@ message TestAllTypes {
 
   // Nested messages
   oneof nested_type {
-    NestedMessage single_nested_message = 18;
-    NestedEnum single_nested_enum = 21;
+    NestedMessage single_nested_message = 21;
+    NestedEnum single_nested_enum = 22;
   }
 
   // Repeated
@@ -80,18 +80,16 @@ message TestAllTypes {
   repeated string repeated_string = 44;
   repeated bytes repeated_bytes = 45;
 
-  repeated NestedMessage repeated_nested_message = 48;
-
-  repeated NestedEnum repeated_nested_enum = 51;
-
-  repeated string repeated_string_piece = 54 [ctype = STRING_PIECE];
-  repeated string repeated_cord = 55 [ctype = CORD];
-
-  repeated NestedMessage repeated_lazy_message = 57 [lazy = true];
+  // Repeated and nested
+  repeated NestedMessage repeated_nested_message = 51;
+  repeated NestedEnum repeated_nested_enum = 52;
+  repeated string repeated_string_piece = 53 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 54 [ctype = CORD];
+  repeated NestedMessage repeated_lazy_message = 55 [lazy = true];
 
   // Map
-  map<string, string> map_string_string = 58;
-  map<int64, NestedTestAllTypes> map_int64_nested_type = 59;
+  map<string, string> map_string_string = 61;
+  map<int64, NestedTestAllTypes> map_int64_nested_type = 62;
 }
 
 // This proto includes a recursively nested message.

--- a/tests/simple/BUILD.bazel
+++ b/tests/simple/BUILD.bazel
@@ -34,6 +34,8 @@ go_test(
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
         "//proto/test/v1:simple_go_proto",
+        "//proto/test/v1/proto2:test_all_types_go_proto",
+        "//proto/test/v1/proto3:test_all_types_go_proto",
         "//tools/celrpc:go_default_library",
     ],
     # This is the magic setting that lets external invokers see

--- a/tests/simple/testdata/proto2.textproto
+++ b/tests/simple/testdata/proto2.textproto
@@ -1,2 +1,43 @@
 name: "proto2"
 description: "Protocol buffer version 2 tests.  See notes for the available set of protos for tests."
+section {
+  name: "singular_read"
+  description: "Reading the singlular fields."
+  test {
+    name: "int32"
+    expr: "x.single_int32"
+    type_env: {
+      name: "x"
+      ident: { type: { message_type: "google.api.expr.test.v1.proto2.TestAllTypes" } }
+    }
+    bindings: {
+      key: "x"
+      value: { value: { object_value: {
+            [type.googleapis.com/google.api.expr.test.v1.proto2.TestAllTypes]
+            { single_int32: 17 }
+          }}}
+    }
+    value: { int64_value: 17 }
+  }
+}
+section {
+  name: "singular_literal"
+  description: "Literals with singular fields set."
+  test {
+    name: "int64_nocontainer"
+    expr: "google.api.expr.test.v1.proto2.TestAllTypes{single_int64: 17}"
+    value: { object_value: {
+            [type.googleapis.com/google.api.expr.test.v1.proto2.TestAllTypes]
+            { single_int64: 17 }
+          }}
+  }
+  test {
+    name: "int64"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_int64: 17}"
+    value: { object_value: {
+            [type.googleapis.com/google.api.expr.test.v1.proto2.TestAllTypes]
+            { single_int64: 17 }
+          }}
+  }
+}

--- a/tests/simple/testdata/proto3.textproto
+++ b/tests/simple/testdata/proto3.textproto
@@ -1,2 +1,22 @@
 name: "proto3"
 description: "Protocol buffer version 3 tests.  See notes for the available set of protos for tests."
+section {
+  name: "singular_read"
+  description: "Reading the singlular fields."
+  test {
+    name: "int32"
+    expr: "x.single_int32"
+    type_env: {
+      name: "x"
+      ident: { type: { message_type: "google.api.expr.test.v1.proto3.TestAllTypes" } }
+    }
+    bindings: {
+      key: "x"
+      value: { value: { object_value: {
+            [type.googleapis.com/google.api.expr.test.v1.proto3.TestAllTypes]
+            { single_int32: 17 }
+          }}}
+    }
+    value: { int64_value: 17 }
+  }
+}

--- a/tests/simple/testdata/proto3.textproto
+++ b/tests/simple/testdata/proto3.textproto
@@ -20,3 +20,24 @@ section {
     value: { int64_value: 17 }
   }
 }
+section {
+  name: "singular_literal"
+  description: "Literals with singular fields set."
+  test {
+    name: "int64_nocontainer"
+    expr: "google.api.expr.test.v1.proto3.TestAllTypes{single_int64: 17}"
+    value: { object_value: {
+            [type.googleapis.com/google.api.expr.test.v1.proto3.TestAllTypes]
+            { single_int64: 17 }
+          }}
+  }
+  test {
+    name: "int64"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_int64: 17}"
+    value: { object_value: {
+            [type.googleapis.com/google.api.expr.test.v1.proto3.TestAllTypes]
+            { single_int64: 17 }
+          }}
+  }
+}


### PR DESCRIPTION
Allows conformance tests to bind variables to protobuf message values, and to expect protobuf messages as evaluation results.  Both proto2 and proto3 are supported.

Adds initial conformance tests for proto2 and proto3 - just enough to demonstrate that the plumbing works.  More conformance tests will be added in future PRs.

The C++ filter written to parse expanded "Any" messages in textproto is no longer required and will be removed in a future PR.
