### PR TITLE
Add basic tests and update lexis

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -95,6 +95,7 @@ BYTES_LIT      ::= [bB] STRING_LIT
 ESCAPE         ::= \ [bfnrt"'\]
                  | \ x HEXDIGIT HEXDIGIT
                  | \ u HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
+                 | \ U HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
                  | \ [0-3] [0-7] [0-7]
 NEWLINE        ::= \r\n | \r | \n
 BOOL_LIT       ::= "true" | "false"

--- a/tests/simple/testdata/basic.textproto
+++ b/tests/simple/testdata/basic.textproto
@@ -63,6 +63,16 @@ section {
     expr: '{}'
     value: { map_value: {} }
   }
+  test {
+    name: "self_eval_string_raw_prefix_triple_double"
+    expr: 'r""""""'
+    value: { string_value: "" }
+  }
+  test {
+    name: "self_eval_string_raw_prefix_triple_single"
+    expr: "r''''''"
+    value: { string_value: "" }
+  }
 }
 section {
   name: "self_eval_nonzeroish"
@@ -132,6 +142,36 @@ section {
     name: "self_eval_bool_true"
     expr: "true"
     value: { bool_value: true }
+  }
+  test {
+    name: "self_eval_int_hex"
+    expr: "0x55555555"
+    value: { int64_value: 1431655765 }
+  }
+  test {
+    name: "self_eval_int_hex_negative"
+    expr: "-0x55555555"
+    value: { int64_value: -1431655765 }
+  }
+  test {
+    name: "self_eval_uint_hex"
+    expr: "0x55555555u"
+    value: { uint64_value: 1431655765 }
+  }
+  test {
+    name: "self_eval_unicode_escape_four"
+    expr: '"\\u270c"'
+    value: { string_value: "\xe2\x9c\x8c" }
+  }
+  test {
+    name: "self_eval_unicode_escape_eight"
+    expr: '"\\U0001f431"'
+    value: { string_value: "\xf0\x9f\x90\xb1" }
+  }
+  test {
+    name: "self_eval_ascii_escape_seq"
+    expr: '"\\a\\b\\f\\n\\r\\t\\v\\"\\\'\\\\"'
+    value: { string_value: "\a\b\f\n\r\t\v\"'\\" }
   }
 }
 section {

--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -78,7 +78,7 @@ section {
   test {
     name: "no_string_normalization_surrogate"
     description: "Should not replace surrogate pairs."
-    expr: "'\\U0001F436' == '\\uD83D\\uDC36'"
+    expr: "'\\U0001F436' == '\\xef\\xbf\\xbd\\xef\\xbf\\bd'"
     value: { bool_value: false }
   }
   test {


### PR DESCRIPTION
This change adds more basic tests for string and integer literals. It also updates the lexis to include the 8 hexadecimal digit variant of Unicode code point escape sequences.