### PR TITLE
Conformance: eval both checked and parsed ASTs.

### DIFF
--- a/tests/simple/simple.go
+++ b/tests/simple/simple.go
@@ -158,6 +158,7 @@ type runConfig struct {
 	parseClient *celrpc.ConfClient
 	checkClient *celrpc.ConfClient
 	evalClient  *celrpc.ConfClient
+	checkedOnly bool
 }
 
 // RunTest runs the test described by t, returning an error for any
@@ -216,24 +217,33 @@ func (r *runConfig) RunTest(t *spb.SimpleTest) error {
 		// TODO: validate that the inferred type is compatible
 		// with the expected value, if any, in the eval matcher.
 	}
-	// TODO: if check phase disabled, check anyhow and ensure it fails.
 
 	// Eval
-	var ereq exprpb.EvalRequest
-	if checkedExpr == nil {
-		ereq = exprpb.EvalRequest{
+	if !r.checkedOnly {
+		err = r.RunEval(t, &exprpb.EvalRequest{
 			ExprKind:  &exprpb.EvalRequest_ParsedExpr{ParsedExpr: parsedExpr},
 			Bindings:  t.Bindings,
 			Container: t.Container,
-		}
-	} else {
-		ereq = exprpb.EvalRequest{
-			ExprKind:  &exprpb.EvalRequest_CheckedExpr{CheckedExpr: checkedExpr},
-			Bindings:  t.Bindings,
-			Container: t.Container,
+		})
+		if err != nil {
+			return err
 		}
 	}
-	eres, err := r.evalClient.Eval(context.Background(), &ereq)
+	if checkedExpr != nil {
+		err = r.RunEval(t, &exprpb.EvalRequest{
+			ExprKind:  &exprpb.EvalRequest_ParsedExpr{ParsedExpr: parsedExpr},
+			Bindings:  t.Bindings,
+			Container: t.Container,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *runConfig) RunEval(t *spb.SimpleTest, ereq *exprpb.EvalRequest) error {
+	eres, err := r.evalClient.Eval(context.Background(), ereq)
 	if err != nil {
 		return fmt.Errorf("%s: Fatal eval RPC error: %v", t.Name, err)
 	}

--- a/tests/simple/simple.go
+++ b/tests/simple/simple.go
@@ -231,7 +231,7 @@ func (r *runConfig) RunTest(t *spb.SimpleTest) error {
 	}
 	if checkedExpr != nil {
 		err = r.RunEval(t, &exprpb.EvalRequest{
-			ExprKind:  &exprpb.EvalRequest_ParsedExpr{ParsedExpr: parsedExpr},
+			ExprKind:  &exprpb.EvalRequest_CheckedExpr{CheckedExpr: checkedExpr},
 			Bindings:  t.Bindings,
 			Container: t.Container,
 		})

--- a/tests/simple/simple_test.go
+++ b/tests/simple/simple_test.go
@@ -42,6 +42,7 @@ var (
 	flagParseServerCmd string
 	flagCheckServerCmd string
 	flagEvalServerCmd  string
+	flagCheckedOnly    bool
 	flagSkipTests      stringArray
 	rc                 *runConfig
 )
@@ -51,6 +52,7 @@ func init() {
 	flag.StringVar(&flagParseServerCmd, "parse_server", "", "path to command for parse server")
 	flag.StringVar(&flagCheckServerCmd, "check_server", "", "path to command for check server")
 	flag.StringVar(&flagEvalServerCmd, "eval_server", "", "path to command for eval server")
+	flag.BoolVar(&flagCheckedOnly, "checked_only", false, "skip tests which skip type checking")
 	flag.Var(&flagSkipTests, "skip_test", "name(s) of tests to skip. can be set multiple times. to skip the following tests: f1/s1/t1, f1/s1/t2, f1/s2/*, f2/s3/t3, you give the arguments --skip_test=f1/s1/t1,t2;s2 --skip_test=f2/s3/t3")
 	flag.Parse()
 }
@@ -99,6 +101,7 @@ func initRunConfig() (*runConfig, error) {
 	rc.parseClient = servers[pCmd]
 	rc.checkClient = servers[cCmd]
 	rc.evalClient = servers[eCmd]
+	rc.checkedOnly = flagCheckedOnly
 	return &rc, nil
 }
 
@@ -193,7 +196,7 @@ func TestSimpleFile(t *testing.T) {
 			t.Logf("Running tests in section %v\n", section.Name)
 			for _, test := range section.Test {
 				testPath := sectionPath + "/" + test.Name
-				if contains(skipTests, testPath) {
+				if contains(skipTests, testPath) || (flagCheckedOnly && test.DisableCheck) {
 					t.Logf("Skipping test name %v\n", test.Name)
 					continue
 				}


### PR DESCRIPTION
Also add a flag to skip tests which skip type checking, so checked-only
evaluators don't have to maintain their own list of tests to skip.