### PR TITLE
Revert "Fix test by removing invalid double nesting of value"

### DIFF
--- a/tests/simple/testdata/dynamic.textproto
+++ b/tests/simple/testdata/dynamic.textproto
@@ -164,12 +164,10 @@ section {
     }
     bindings {
       key: "x"
-      value {
-        object_value {
-          [type.googleapis.com/google.protobuf.Int64Value]
-          { value: 2000000 }
-        }
-      }
+      value { value { object_value {
+            [type.googleapis.com/google.protobuf.Int64Value]
+            { value: 2000000 }
+          } } }
     }
     value { int64_value: 2000000 }
   }


### PR DESCRIPTION
This reverts commit 29370528731ae703183537e7072b5ad6c8c0bf96.