### PR TITLE
Remove bad type specification in example

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -85,7 +85,7 @@ citizens of CEL:
 ```proto
 has(account.properties.id)
   && (type(account.properties.id) == string
-     || type(account.properties.id) == list(string))
+     || type(account.properties.id) == list)
 ```
 
 CEL's default type checker deals with a mixture of dynamic and static typing;


### PR DESCRIPTION
The type should just be `list` and not `list(string)` which we moved away from quite some time ago.