### PR TITLE
Disable typecheck for null < x conformance test

### DIFF
--- a/tests/simple/testdata/comparisons.textproto
+++ b/tests/simple/testdata/comparisons.textproto
@@ -1127,10 +1127,7 @@ section {
     eval_error: {
       errors: { message: "no such overload" }
     }
-    type_env: {
-      name: "x",
-      ident: { type: { null: NULL_VALUE } }
-    }
+    disable_check: true
     bindings: {
       key: "x",
       value: { value: { null_value: NULL_VALUE } }


### PR DESCRIPTION
In the spec there is no overload that could match null < x, so implementations should be allowed to fail type checking for this.

Cel-go doesn't, because it considers well-known types nullable, so e.g the overload timestamp < timestamp matches this at type-checking (but not at run-time).