### PR TITLE
Ensure that numeric timezones in tests are spec-consistent

### DIFF
--- a/tests/simple/testdata/timestamps.textproto
+++ b/tests/simple/testdata/timestamps.textproto
@@ -115,7 +115,7 @@ section {
   }
   test {
     name: "getDayOfMonth_numerical_neg"
-    expr: "timestamp('2009-02-13T02:00:00Z').getDayOfMonth('-2:30')"
+    expr: "timestamp('2009-02-13T02:00:00Z').getDayOfMonth('-02:30')"
     value: { int64_value: 11 }
   }
   test {
@@ -135,12 +135,12 @@ section {
   }
   test {
     name: "getFullYear"
-    expr: "timestamp('2009-02-13T23:31:30Z').getFullYear('-9:30')"
+    expr: "timestamp('2009-02-13T23:31:30Z').getFullYear('-09:30')"
     value: { int64_value: 2009 }
   }
   test {
     name: "getHours"
-    expr: "timestamp('2009-02-13T23:31:30Z').getHours('2:00')"
+    expr: "timestamp('2009-02-13T23:31:30Z').getHours('02:00')"
     value: { int64_value: 1 }
   }
   test {


### PR DESCRIPTION
Add leading zeros to numeric timezone arguments. It's possible that some implementations may be more lenient in the timezones accepted, but the spec and tests should declare support for the more conservative format.

Closes #194 