### PR TITLE
Document the duration string format supported by core implementations

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -1790,7 +1790,10 @@ See [cel-go/issues/9](https://github.com/google/cel-go/issues/9).
       (string) -> google.protobuf.Duration
     </td>
     <td>
-      type conversion, duration should end with "s", which stands for seconds
+      Type conversion. Duration strings should support the following suffixes:
+      "h" (hour), "m" (minute), "s" (second), "ms" (millisecond),
+      "us" (microsecond), and "ns" (nanosecond).
+      Duration strings may also represent compound durations, e.g. "1m6s"
     </td>
   </tr>
   <tr>

--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -1793,7 +1793,8 @@ See [cel-go/issues/9](https://github.com/google/cel-go/issues/9).
       Type conversion. Duration strings should support the following suffixes:
       "h" (hour), "m" (minute), "s" (second), "ms" (millisecond),
       "us" (microsecond), and "ns" (nanosecond).
-      Duration strings may also represent compound durations, e.g. "1m6s"
+      Duration strings may be zero, negative, fractional, and/or compound.
+      Examples: "0", "-1.5h", "1m6s"
     </td>
   </tr>
   <tr>
@@ -2269,7 +2270,8 @@ See [cel-go/issues/9](https://github.com/google/cel-go/issues/9).
       (string) -> google.protobuf.Timestamp
     </td>
     <td>
-      Type conversion of strings to timestamps according to RFC3339. Example: "1972-01-01T10:00:20.021-05:00"
+      Type conversion of strings to timestamps according to RFC3339.
+      Example: "1972-01-01T10:00:20.021-05:00"
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
Update the spec to indicate the duration string format supported by the core CEL implementations:

Update the spec to indicate the format supported by C++, Java, and Go:
https://github.com/abseil/abseil-cpp/blob/master/absl/time/time.h#L577
https://github.com/ThreeTen/threeten-extra/blob/master/src/main/java/org/threeten/extra/AmountFormats.java#L327
https://pkg.go.dev/time#ParseDuration

Closes #185 