### PR TITLE
Update the get_milliseconds test to match the spec

### DIFF
--- a/tests/simple/testdata/timestamps.textproto
+++ b/tests/simple/testdata/timestamps.textproto
@@ -325,7 +325,7 @@ section {
   }
   test {
     name: "get_milliseconds"
-    description: "Need to import a variable to get milliseconds."
+    description: "Obtain the milliseconds component of the duration. Note, this is not the same as converting the duration to milliseconds. This behavior will be deprecated."
     expr: "x.getMilliseconds()"
     type_env {
       name: "x"
@@ -345,7 +345,7 @@ section {
         }
       }
     }
-    value: { int64_value: 123123 }
+    value: { int64_value: 123 }
   }
   test {
     name: "get_minutes"

--- a/tests/simple/testdata/timestamps.textproto
+++ b/tests/simple/testdata/timestamps.textproto
@@ -339,13 +339,13 @@ section {
             [type.googleapis.com/google.protobuf.Duration]
             {
               seconds: 123
-              nanos: 123456789
+              nanos:321456789
             }
           }
         }
       }
     }
-    value: { int64_value: 123 }
+    value: { int64_value: 321 }
   }
   test {
     name: "get_minutes"


### PR DESCRIPTION
Closes #175

Bug also filed for https://github.com/google/cel-go/issues/453 to address spec conformance.