### PR TITLE
Fix spec `ESCAPE` definition mismatch

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -149,7 +149,7 @@ STRING_LIT     ::= [rR]? ( "    ~( " | NEWLINE )*  "
                          | '''  ~'''*              '''
                          )
 BYTES_LIT      ::= [bB] STRING_LIT
-ESCAPE         ::= \ [bfnrt"'\]
+ESCAPE         ::= \ [abfnrtv\?"'`]
                  | \ x HEXDIGIT HEXDIGIT
                  | \ u HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
                  | \ U HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT


### PR DESCRIPTION
The BNF definition of `ESCAPE` provided does not match the text.

> Escape sequences are a backslash (`\ `) followed by one of the following:
> 
> *   A punctuation mark representing itself:
>     *   `\ `: backslash
>     *   `?`: question mark
>     *   `"`: double quote
>     *   `'`: single quote
>     *   `` ` ``: backtick
> *   A code for whitespace:
>     *   `a`: bell
>     *   `b`: backspace
>     *   `f`: form feed
>     *   `n`: line feed
>     *   `r`: carriage return
>     *   `t`: horizontal tab
>     *   `v`: vertical tab

The BNF is missing `a`, `v`, `?`, `` ` ``
```
ESCAPE         ::= \ [bfnrt"'\]
                 | \ x HEXDIGIT HEXDIGIT
                 | \ u HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
                 | \ U HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
                 | \ [0-3] [0-7] [0-7]
```