### PR TITLE
Fix `Member`/`Primary` BNF for messages

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -79,12 +79,12 @@ Unary          = Member
 Member         = Primary
                | Member "." IDENT ["(" [ExprList] ")"]
                | Member "[" Expr "]"
-               | Member "{" [FieldInits] [","] "}"
                ;
 Primary        = ["."] IDENT ["(" [ExprList] ")"]
                | "(" Expr ")"
                | "[" [ExprList] [","] "]"
                | "{" [MapInits] [","] "}"
+               | ["."] IDENT { "." IDENT } "{" [FieldInits] [","] "}"
                | LITERAL
                ;
 ExprList       = Expr {"," Expr} ;


### PR DESCRIPTION
Messages can't start with anything other than simple or qualified names.

> a message by `M{f1: e1, f2: e2, ..., fN:
> eN}`, where `M` must be a simple or qualified name which resolves to a message
> type (see [Name Resolution](#name-resolution))

> ### Name Resolution
> ...
> Resolution works as follows. If `a.b` is a name to be resolved in the context of
> a protobuf declaration with scope `A.B`, then resolution is attempted, in order,
> as `A.B.a.b`, `A.a.b`, and finally `a.b`. To override this behavior, one can use
> `.a.b`; this name will only be attempted to be resolved in the root scope, i.e.
> as `a.b`.

Also messages are a valid `Primary` for `Member` expressions.

> A field selection expression, `e.f`, can be applied both to messages and to maps