### PR TITLE
Adjust parser recursion limits

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -94,17 +94,21 @@ MapInits       = Expr ":" Expr {"," Expr ":" Expr} ;
 
 Implementations are required to support at least:
 
-*   32 levels of nested expressions;
-*   32 repetitions of self-recursive or repetitive rules, i.e.:
+*   24-32 repetitions of repeating rules, i.e.:
     *   32 terms separated by `||` in a row;
     *   32 terms separated by `&&` in a row;
-    *   32 relations in a row;
-    *   32 binary arithmetic operators of the same precedence in a row;
-    *   32 selection (`.`) operators in a row;
-    *   32 indexing (`[_]`) operators in a row;
     *   32 function call arguments;
     *   list literals with 32 elements;
-    *   map or message literals with 32 fields.
+    *   map or message literals with 32 fields;
+    *   24 consecutive ternary conditionals `?:`;
+    *   24 binary arithmetic operators of the same precedence in a row;
+    *   24 relations in a row.
+*   12 repetitions of recursive rules, i.e:
+    *   12 nested function calls;
+    *   12 selection (`.`) operators in a row;
+    *   12 indexing (`[_]`) operators in a row;
+    *   12 nested list, map, or message literals.
+
 
 This grammar corresponds to the following operator precedence and associativity:
 

--- a/tests/simple/testdata/parse.textproto
+++ b/tests/simple/testdata/parse.textproto
@@ -5,8 +5,8 @@ section {
   description: "Deep parse trees which all implementations must support."
   test {
     name: "list_index"
-    description: "Member = Member '[' Expr ']'"
-    expr: "a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[a[0]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]"
+    description: "Member = Member '[' Expr ']'. Nested indices are supported up to 12 times."
+    expr: "a[a[a[a[a[a[a[a[a[a[a[a[0]]]]]]]]]]]]"
     type_env {
       name: "a"
       ident { type { list_type { elem_type { primitive: INT64 } } } }
@@ -19,16 +19,28 @@ section {
   }
   test {
     name: "message_literal"
-    description: "Member = Member '{' [FieldInits] '}'"
+    description: "Member = Member '{' [FieldInits] '}'. Nested messages supported up to 12 levels deep."
     container: "google.api.expr.test.v1.proto3"
-    expr: "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{payload: TestAllTypes{single_int64: 137}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}.payload.single_int64"
+    expr: "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{payload: TestAllTypes{single_int64: 137}}}}}}}}}}}}.payload.single_int64"
     value { int64_value: 0 }
   }
   test {
     name: "funcall"
-    description: "Primary = ['.'] IDENT ['(' [ExprList] ')']"
-    expr: "int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(7))))))))))))))))))))))))))))))))"
+    description: "Primary = ['.'] IDENT ['(' [ExprList] ')']. Nested function calls supported up to 12 levels deep."
+    expr: "int(uint(int(uint(int(uint(int(uint(int(uint(int(uint(7))))))))))))"
     value { int64_value: 7 }
+  }
+  test {
+    name: "list_literal"
+    description: "Primary = '[' [ExprList] ']'. Nested list literals up to 12 levels deep."
+    expr: "size([[[[[[[[[[[[0]]]]]]]]]]]])"
+    value { int64_value: 1 }
+  }
+  test {
+    name: "map_literal"
+    description: "Primary = '{' [MapInits] '}'. Nested map literals up to 12 levels deep."
+    expr: "size({0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: 'foo'}}}}}}}}}}}})"
+    value { int64_value: 1 }
   }
   test {
     name: "parens"
@@ -36,50 +48,38 @@ section {
     expr: "((((((((((((((((((((((((((((((((7))))))))))))))))))))))))))))))))"
     value { int64_value: 7 }
   }
-  test {
-    name: "list_literal"
-    description: "Primary = '[' [ExprList] ']'"
-    expr: "size([[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[0]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]])"
-    value { int64_value: 1 }
-  }
-  test {
-    name: "map_literal"
-    description: "Primary = '{' [MapInits] '}'"
-    expr: "size({0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: {0: 'foo'}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}})"
-    value { int64_value: 1 }
-  }
 }
 section {
   name: "repeat"
   description: "Repetitive parse trees which all implementations must support."
   test {
     name: "conditional"
-    description: "Expr = ConditionalOr ['?' ConditionalOr ':' Expr]"
-    expr: "true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : false"
+    description: "Expr = ConditionalOr ['?' ConditionalOr ':' Expr]. Chained ternary operators up to 24 levels."
+    expr: "true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : true ? true : false"
     value { bool_value: true }
   }
   test {
     name: "or"
-    description: "ConditionalOr = [ConditionalOr '||'] ConditionalAnd"
+    description: "ConditionalOr = [ConditionalOr '||'] ConditionalAnd. Logical OR statements with 32 conditions."
     expr: "false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || false || true"
     value { bool_value: true }
   }
   test {
     name: "and"
-    description: "ConditionalAnd = [ConditionalAnd '&&'] Relation"
+    description: "ConditionalAnd = [ConditionalAnd '&&'] Relation. Logical AND statements with 32 conditions."
     expr: "true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && true && false"
     value { bool_value: false }
   }
   test {
     name: "add_sub"
-    description: "Addition = [Addition ('+' | '-')] Multiplication"
-    expr: "3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3"
+    description: "Addition = [Addition ('+' | '-')] Multiplication. Addition operators are supported up to 24 times consecutively."
+    expr: "3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3 - 3 + 3"
     value { int64_value: 3 }
   }
   test {
     name: "mul_div"
-    description: "Multiplication = [Multiplication ('*' | '/' | '%')] Unary"
-    expr: "4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4"
+    description: "Multiplication = [Multiplication ('*' | '/' | '%')] Unary. Multiplication operators are supported up to 24 times consecutively."
+    expr: "4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4 * 4 / 4"
     value { int64_value: 4 }
   }
   test {
@@ -96,32 +96,32 @@ section {
   }
   test {
     name: "select"
-    description: "Member = Member '.' IDENT ['(' [ExprList] ')']"
+    description: "Member = Member '.' IDENT ['(' [ExprList] ')']. Selection is supported up to 12 times consecutively."
     container: "google.api.expr.test.v1.proto3"
-    expr: "NestedTestAllTypes{}.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.child.payload.single_int32"
+    expr: "NestedTestAllTypes{}.child.child.child.child.child.child.child.child.child.child.payload.single_int32"
     value { int64_value: 0 }
   }
   test {
     name: "index"
-    description: "Member = Member '[' Expr ']'"
-    expr: "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[['foo']]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]"
+    description: "Member = Member '[' Expr ']'. Indexing is supported up to 12 times consecutively."
+    expr: "[[[[[[[[[[[['foo']]]]]]]]]]]][0][0][0][0][0][0][0][0][0][0][0][0]"
     value { string_value: "foo" }
   }
   test {
     name: "list_literal"
-    description: "Primary = '[' [ExprList] ']'"
+    description: "Primary = '[' [ExprList] ']'. List literals with up to 32 elements."
     expr: "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31][17]"
     value { int64_value: 17 }
   }
   test {
     name: "map_literal"
-    description: "Primary = '{' [MapInits] '}'"
+    description: "Primary = '{' [MapInits] '}'. Map literals with up to 32 entries."
     expr: "{0: 'zero', 1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five', 6: 'six', 7: 'seven', 8: 'eight', 9: 'nine', 10: 'ten', 11: 'eleven', 12: 'twelve', 13: 'thirteen', 14: 'fourteen', 15: 'fifteen', 16: 'sixteen', 17: 'seventeen', 18: 'eighteen', 19: 'nineteen', 20: 'twenty', 21: 'twenty-one', 22: 'twenty-two', 23: 'twenty-three', 24: 'twenty-four', 25: 'twenty-five', 26: 'twenty-six', 27: 'twenty-seven', 28: 'twenty-eight', 29: 'twenty-nine', 30: 'thirty', 31: 'thirty-one'}[17]"
     value { string_value: 'seventeen' }
   }
   test {
     name: "message_literal"
-    description: "Member = Member '{' [FieldInits] '}'"
+    description: "Member = Member '{' [FieldInits] '}'. Message literals with up to 32 fields."
     container: "google.api.expr.test.v1.proto3"
     expr: "TestAllTypes{single_int32: 5, single_int64: 10, single_uint32: 15u, single_uint64: 20u, single_sint32: 25, single_sint64: 30, single_fixed32: 35u, single_fixed64: 40u, single_float: 45.0, single_double: 50.0, single_bool: true, single_string: 'sixty', single_bytes: b'sixty-five', single_value: 70.0, single_int64_wrapper: 75, single_int32_wrapper: 80, single_double_wrapper: 85.0, single_float_wrapper: 90.0, single_uint64_wrapper: 95u, single_uint32_wrapper: 100u, single_string_wrapper: 'one hundred five', single_bool_wrapper: true, repeated_int32: [115], repeated_int64: [120], repeated_uint32: [125u], repeated_uint64: [130u], repeated_sint32: [135], repeated_sint64: [140], repeated_fixed32: [145u], repeated_fixed64: [150u], repeated_sfixed32: [155], repeated_float: [160.0]}.single_sint64"
     value { int64_value: 30 }


### PR DESCRIPTION
Adjust the parser recursion limits to mirror production limits

CEL implementations must support certain minimum levels of rule recursion and
repetition. Originally, these values were set at 32 for all operations whether the
limit was practical or not. However, the initial limits proved difficult to encode
into abstract syntax trees which would not exceed the stack recursion limits of
gRPC and protobuf. These limits have been adjusted for practicality and with
production recursion limits in mind.