### PR TITLE
Add support for piping conformance tests using base64 encoded messages.

### DIFF
--- a/tests/simple/simple_test.go
+++ b/tests/simple/simple_test.go
@@ -19,6 +19,7 @@ import (
 
 	spb "github.com/google/cel-spec/proto/test/v1/testpb"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
 	// The following are needed to link in these proto libraries
 	// which are needed dynamically, despite not being explicitly
 	// used in the Go source.
@@ -28,12 +29,12 @@ import (
 
 type stringArray []string
 
-//String implements flag.Value.String()
+// String implements flag.Value.String()
 func (i *stringArray) String() string {
 	return strings.Join(*i, " ")
 }
 
-//Set implements flag.Value.Set()
+// Set implements flag.Value.Set()
 func (i *stringArray) Set(value string) error {
 	*i = append(*i, value)
 	return nil
@@ -48,6 +49,7 @@ var (
 	flagSkipCheck      bool
 	flagSkipTests      stringArray
 	flagPipe           bool
+	flagPipeBase64     bool
 	rc                 *runConfig
 )
 
@@ -60,6 +62,8 @@ func init() {
 	flag.BoolVar(&flagSkipCheck, "skip_check", false, "force skipping the check phase")
 	flag.Var(&flagSkipTests, "skip_test", "name(s) of tests to skip. can be set multiple times. to skip the following tests: f1/s1/t1, f1/s1/t2, f1/s2/*, f2/s3/t3, you give the arguments --skip_test=f1/s1/t1,t2;s2 --skip_test=f2/s3/t3")
 	flag.BoolVar(&flagPipe, "pipe", false, "Use pipes instead of gRPC")
+	flag.BoolVar(&flagPipeBase64, "pipe_base64", false, "Use base64 encoded wire format proto in pipes (default JSON).")
+
 	flag.Parse()
 }
 
@@ -99,7 +103,7 @@ func initRunConfig() (*runConfig, error) {
 		var cli celrpc.ConfClient
 		var err error
 		if flagPipe {
-			cli, err = celrpc.NewPipeClient(cmd)
+			cli, err = celrpc.NewPipeClient(cmd, flagPipeBase64)
 		} else {
 			cli, err = celrpc.NewGrpcClient(cmd)
 		}

--- a/tools/celrpc/BUILD.bazel
+++ b/tools/celrpc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -17,4 +17,21 @@ go_library(
         "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
+)
+
+go_test(
+    name = "celrpc_test",
+    args = [
+        "--server_cmd=$(rootpath //tools/celrpc/testpipeimpl/main)"
+    ],
+    data = [
+        "//tools/celrpc/testpipeimpl/main",
+    ],
+    deps = [
+        "@io_bazel_rules_go//go/tools/bazel",
+    ],
+    srcs = [
+        "celrpc_test.go"
+    ],
+    embed = [":go_default_library"],
 )

--- a/tools/celrpc/celrpc_test.go
+++ b/tools/celrpc/celrpc_test.go
@@ -1,0 +1,175 @@
+package celrpc
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+
+	confpb "google.golang.org/genproto/googleapis/api/expr/conformance/v1alpha1"
+)
+
+var (
+	serverCmd        string
+	serverBase64Flag string
+)
+
+func init() {
+	flag.StringVar(&serverCmd, "server_cmd", "", "cmd to start conformance service implementation")
+	flag.StringVar(&serverBase64Flag, "server_base64_flag", "-use_base64", "flag the pipe server uses to enable base64 encoding")
+	flag.Parse()
+}
+
+func TestPipeParse(t *testing.T) {
+	for _, useBase64 := range []bool{false, true} {
+		t := t
+		t.Run(fmt.Sprintf("useBase64=%v", useBase64), func(t *testing.T) {
+			serverCmd, err := bazel.Runfile(serverCmd)
+
+			if useBase64 {
+				serverCmd = fmt.Sprintf("%s %s", serverCmd, serverBase64Flag)
+			}
+
+			if err != nil {
+				t.Fatalf("error loading bazel runfile path, %v", err)
+			}
+			conf, err := NewPipeClient(serverCmd, useBase64)
+			defer conf.Shutdown()
+			if err != nil {
+				t.Fatalf("error initializing client got %v wanted nil", err)
+			}
+
+			r := make(chan *confpb.ParseResponse)
+			e := make(chan error)
+			go func() {
+				resp, err := conf.Parse(context.Background(), &confpb.ParseRequest{
+					CelSource: "1 + 1",
+				})
+				e <- err
+				r <- resp
+			}()
+
+			var resp *confpb.ParseResponse
+			select {
+			case <-time.After(2 * time.Second):
+				err = errors.New("timeout")
+			case err = <-e:
+				resp = <-r
+			}
+
+			if err != nil {
+				t.Fatalf("error from pipe: %v", err)
+			}
+
+			if len(resp.Issues) > 0 {
+				t.Errorf("Issues: got %v expected none", resp.Issues)
+			}
+
+			if resp.GetParsedExpr().GetExpr().GetCallExpr().GetFunction() != "_+_" {
+				t.Errorf("unexpected ast got: %s wanted _+_(1, 1)", resp.GetParsedExpr())
+			}
+		})
+	}
+
+}
+
+func TestPipeEval(t *testing.T) {
+	for _, useBase64 := range []bool{false, true} {
+		t := t
+		t.Run(fmt.Sprintf("useBase64=%v", useBase64), func(t *testing.T) {
+			serverCmd, err := bazel.Runfile(serverCmd)
+
+			if useBase64 {
+				serverCmd = fmt.Sprintf("%s %s", serverCmd, serverBase64Flag)
+			}
+
+			if err != nil {
+				t.Fatalf("error loading bazel runfile path, %v", err)
+			}
+			conf, err := NewPipeClient(serverCmd, useBase64)
+			defer conf.Shutdown()
+			if err != nil {
+				t.Fatalf("error initializing client got %v wanted nil", err)
+			}
+
+			r := make(chan *confpb.EvalResponse)
+			e := make(chan error)
+			go func() {
+				resp, err := conf.Eval(context.Background(), &confpb.EvalRequest{})
+				e <- err
+				r <- resp
+			}()
+
+			var resp *confpb.EvalResponse
+			select {
+			case <-time.After(2 * time.Second):
+				err = errors.New("timeout")
+			case err = <-e:
+				resp = <-r
+			}
+
+			if err != nil {
+				t.Fatalf("error from pipe: %v", err)
+			}
+
+			if len(resp.Issues) > 0 {
+				t.Errorf("Issues: got %v expected none", resp.Issues)
+			}
+
+			if resp.GetResult().GetValue().GetInt64Value() != 2 {
+				t.Errorf("unexpected eval response got: %s wanted 2", resp)
+			}
+		})
+	}
+}
+
+func TestPipeCheck(t *testing.T) {
+	for _, useBase64 := range []bool{false, true} {
+		t := t
+		t.Run(fmt.Sprintf("useBase64=%v", useBase64), func(t *testing.T) {
+			serverCmd, err := bazel.Runfile(serverCmd)
+
+			if useBase64 {
+				serverCmd = fmt.Sprintf("%s %s", serverCmd, serverBase64Flag)
+			}
+
+			if err != nil {
+				t.Fatalf("error loading bazel runfile path, %v", err)
+			}
+			conf, err := NewPipeClient(serverCmd, useBase64)
+			defer conf.Shutdown()
+			if err != nil {
+				t.Fatalf("error initializing client got %v wanted nil", err)
+			}
+
+			r := make(chan *confpb.CheckResponse)
+			e := make(chan error)
+			go func() {
+				resp, err := conf.Check(context.Background(), &confpb.CheckRequest{})
+				e <- err
+				r <- resp
+			}()
+
+			var resp *confpb.CheckResponse
+			select {
+			case <-time.After(2 * time.Second):
+				err = errors.New("timeout")
+			case err = <-e:
+				resp = <-r
+			}
+
+			if err != nil {
+				t.Fatalf("error from pipe: %v", err)
+			}
+
+			if len(resp.Issues) < 1 {
+				t.Errorf("Issues: got %v expected Unimplemented Error", resp.Issues)
+			}
+		})
+	}
+
+}

--- a/tools/celrpc/testpipeimpl/main/BUILD.bazel
+++ b/tools/celrpc/testpipeimpl/main/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+licenses(["notice"])  # Apache 2.0
+
+package(
+    default_visibility = ["//tools/celrpc:__subpackages__"]
+)
+
+go_binary(
+    name="main",
+    srcs = ["main.go"],
+    deps = [
+        "@org_golang_google_genproto//googleapis/api/expr/conformance/v1alpha1:go_default_library",
+        "@org_golang_google_protobuf//encoding/protojson:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
+        "@org_golang_google_genproto//googleapis/rpc/status:go_default_library", 
+        "@org_golang_google_grpc//codes:go_default_library"  
+    ]
+)

--- a/tools/celrpc/testpipeimpl/main/main.go
+++ b/tools/celrpc/testpipeimpl/main/main.go
@@ -1,0 +1,195 @@
+// package main defines a simple implementation of the pipe protocol.
+//
+// This is intended for unit tests and only supports parse '1 + 1'
+// and eval (which deterministically returns 2).
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	confpb "google.golang.org/genproto/googleapis/api/expr/conformance/v1alpha1"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+type codec struct {
+	useBase64 bool
+}
+
+func (c *codec) marshal(in proto.Message) (string, error) {
+	if c.useBase64 {
+		bytes, err := proto.Marshal(in)
+		if err != nil {
+			return "", err
+		}
+		return base64.StdEncoding.EncodeToString(bytes), nil
+	} else {
+		return protojson.MarshalOptions{}.Format(in), nil
+	}
+}
+
+func (c *codec) unmarshal(encoded string, out proto.Message) error {
+	if c.useBase64 {
+		protoBytes, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return err
+		}
+		return proto.Unmarshal(protoBytes, out)
+	} else {
+		return protojson.Unmarshal([]byte(encoded), out)
+	}
+}
+
+func (c *codec) serialize(w *bufio.Writer, out proto.Message) error {
+	output, err := c.marshal(out)
+	if err != nil {
+		return err
+	}
+	_, err = w.WriteString(output + "\n")
+	if err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func getExampleExpr() *exprpb.ParsedExpr {
+	return &exprpb.ParsedExpr{
+		Expr: &exprpb.Expr{
+			ExprKind: &exprpb.Expr_CallExpr{
+				CallExpr: &exprpb.Expr_Call{
+					Function: "_+_",
+					Args: []*exprpb.Expr{
+						{
+							ExprKind: &exprpb.Expr_ConstExpr{
+								ConstExpr: &exprpb.Constant{
+									ConstantKind: &exprpb.Constant_Int64Value{
+										Int64Value: 1,
+									},
+								},
+							},
+						},
+						{
+							ExprKind: &exprpb.Expr_ConstExpr{
+								ConstExpr: &exprpb.Constant{
+									ConstantKind: &exprpb.Constant_Int64Value{
+										Int64Value: 1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func processLoop() int {
+	useBase64 := flag.Bool("use_base64", false, "use_base64 sets the pipe format to base64")
+	flag.Parse()
+	c := codec{
+		useBase64: *useBase64,
+	}
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	for {
+
+		cmd, err := reader.ReadString('\n')
+		if err != nil {
+			return 1
+		}
+
+		cmd = strings.TrimSpace(cmd)
+		if cmd == "exit" {
+			return 0
+		}
+		msg, err := reader.ReadString('\n')
+		if err != nil {
+			return 1
+		}
+
+		switch cmd {
+		case "parse":
+			req := confpb.ParseRequest{}
+			if err := c.unmarshal(msg, &req); err != nil {
+				fmt.Fprintf(os.Stderr, "bad parse req: %v\n", err)
+				return 1
+			}
+			resp := confpb.ParseResponse{
+				Issues: []*statuspb.Status{
+					{
+						Code:    int32(codes.Unimplemented),
+						Message: fmt.Sprintf("parse (%s)", req.CelSource),
+					},
+				},
+			}
+			if req.CelSource == "1 + 1" {
+				resp = confpb.ParseResponse{
+					ParsedExpr: getExampleExpr(),
+				}
+			}
+
+			if err = c.serialize(writer, &resp); err != nil {
+				fmt.Fprintf(os.Stderr, "error serializing parse resp %v\n", err)
+				return 1
+			}
+
+		case "eval":
+			req := confpb.EvalRequest{}
+			if err := c.unmarshal(msg, &req); err != nil {
+				fmt.Fprintf(os.Stderr, "bad eval req: %v\n", err)
+				return 1
+			}
+
+			// toy example only works for 1 + 1
+			resp := confpb.EvalResponse{
+				Result: &exprpb.ExprValue{
+					Kind: &exprpb.ExprValue_Value{
+						Value: &exprpb.Value{
+							Kind: &exprpb.Value_Int64Value{Int64Value: 2},
+						},
+					},
+				},
+			}
+			if err = c.serialize(writer, &resp); err != nil {
+				fmt.Fprintf(os.Stderr, "error serializing parse resp %v\n", err)
+				return 1
+			}
+		case "check":
+			req := confpb.CheckRequest{}
+			if err := c.unmarshal(msg, &req); err != nil {
+				fmt.Fprintf(os.Stderr, "bad check req: %v\n", err)
+				return 1
+			}
+			resp := confpb.CheckResponse{
+				Issues: []*statuspb.Status{
+					{
+						Code:    int32(codes.Unimplemented),
+						Message: "check unimplemented",
+					},
+				},
+			}
+			if err = c.serialize(writer, &resp); err != nil {
+				fmt.Fprintf(os.Stderr, "error serializing check resp %v\n", err)
+				return 1
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "unsupported cmd: %s\n", cmd)
+			return 1
+		}
+	}
+}
+
+func main() {
+	rc := processLoop()
+	os.Exit(rc)
+}


### PR DESCRIPTION
JSON/Proto serialization has some limitations and subtly differnet behavior between environments. Base64 encoding the wire format of the protobuf messages should lead to fewer false positives.