### PR TITLE
Update the conformance service build targets

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,20 +11,10 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    sha256 = "ecba0f04f96b4960a5b250c8e8eeec42281035970aa8852dda73098274d14a1d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "rules_cc",
-    sha256 = "24c8ae1a4b802309ed9fa3580fe815bdca7d4d9b5b21494d92e4b616d83b5e51",
-    strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.tar.gz",
-        "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
     ],
 )
 

--- a/proto/dev/cel/expr/conformance/BUILD.bazel
+++ b/proto/dev/cel/expr/conformance/BUILD.bazel
@@ -5,14 +5,13 @@ package(default_visibility = ["//visibility:public"])
 ##############################################################################
 
 proto_library(
-    name = "conformance_proto",
+    name = "conformance_service_proto",
     srcs = [
         "conformance_service.proto",
     ],
     strip_import_prefix = "/proto",
     deps = [
         "//proto/dev/cel/expr:expr_proto",
-        "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/rpc:status_proto",
     ],
 )
@@ -21,8 +20,8 @@ proto_library(
 # Java
 ##############################################################################
 java_proto_library(
-    name = "conformance_java_proto",
-    deps = [":conformance_proto"],
+    name = "conformance_service_java_proto",
+    deps = [":conformance_service_proto"],
 )
 
 ###############################################################################
@@ -32,9 +31,9 @@ java_proto_library(
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 go_proto_library(
-    name = "conformance_go_proto",
+    name = "conformance_service_go_proto",
     importpath = "dev.cel/expr/conformance",
-    protos = [":conformance_proto"],
+    protos = [":conformance_service_proto"],
     deps = [
         "//proto/dev/cel/expr:expr_go_proto",
         "//proto/dev/cel/expr:google_rpc_status_go_proto",
@@ -46,6 +45,6 @@ go_proto_library(
 ###############################################################################
 
 cc_proto_library(
-    name = "conformance_cc_proto",
-    deps = [":conformance_proto"],
+    name = "conformance_service_cc_proto",
+    deps = [":conformance_service_proto"],
 )

--- a/proto/dev/cel/expr/conformance/conformance_service.proto
+++ b/proto/dev/cel/expr/conformance/conformance_service.proto
@@ -25,7 +25,7 @@ option cc_enable_arenas = true;
 option go_package = "dev.cel/expr/conformance";
 option java_multiple_files = true;
 option java_outer_classname = "ConformanceServiceProto";
-option java_package = "dev.cel.expr";
+option java_package = "dev.cel.expr.conformance";
 
 // Access a CEL implementation from another process or machine.
 // A CEL implementation is decomposed as a parser, a static checker,


### PR DESCRIPTION
Update the go package for conformance protos.

This change also updates the associated WORKSPACE and BUILD.bazel targets