### PR TITLE
Add a buf.yaml for Buf CLI compatibility

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,12 @@
+version: v1
+deps:
+  - buf.build/googleapis/googleapis
+build:
+  excludes: [test]
+lint:
+  ignore:
+    - dev/cel/expr/conformance/proto2/test_all_types.proto
+    - dev/cel/expr/conformance/proto3/test_all_types.proto
+  except:
+    - PACKAGE_VERSION_SUFFIX
+    - ENUM_VALUE_PREFIX


### PR DESCRIPTION
To control which files get synced to https://buf.build/cel/spec.