### PR TITLE
Update the proto, go, and c++ packages

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -2,11 +2,11 @@ version: v1
 deps:
   - buf.build/googleapis/googleapis
 build:
-  excludes: [test]
+  excludes: [test, dev]
 lint:
   ignore:
-    - dev/cel/expr/conformance/proto2/test_all_types.proto
-    - dev/cel/expr/conformance/proto3/test_all_types.proto
+    - cel/expr/conformance/proto2/test_all_types.proto
+    - cel/expr/conformance/proto3/test_all_types.proto
   except:
     - PACKAGE_VERSION_SUFFIX
     - ENUM_VALUE_PREFIX

--- a/proto/cel/expr/BUILD.bazel
+++ b/proto/cel/expr/BUILD.bazel
@@ -1,0 +1,208 @@
+package(default_visibility = ["//visibility:public"])
+
+##############################################################################
+# Common
+##############################################################################
+
+proto_library(
+    name = "expr_proto",
+    srcs = [
+        "checked.proto",
+        "eval.proto",
+        "explain.proto",
+        "syntax.proto",
+        "value.proto",
+    ],
+    strip_import_prefix = "/proto",
+    deps = [
+        "@com_google_googleapis//google/rpc:status_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "syntax_proto",
+    srcs = [
+        "syntax.proto",
+    ],
+    strip_import_prefix = "/proto",
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "checked_proto",
+    srcs = [
+        "checked.proto",
+    ],
+    strip_import_prefix = "/proto",
+    deps = [
+        ":syntax_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "value_proto",
+    srcs = [
+        "value.proto",
+    ],
+    strip_import_prefix = "/proto",
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "eval_proto",
+    srcs = [
+        "eval.proto",
+    ],
+    strip_import_prefix = "/proto",
+    deps = [
+        ":value_proto",
+        "@com_google_googleapis//google/rpc:status_proto",
+    ],
+)
+
+proto_library(
+    name = "explain_proto",
+    srcs = [
+        "explain.proto",
+    ],
+    strip_import_prefix = "/proto",
+    deps = [
+        ":value_proto",
+    ],
+)
+
+##############################################################################
+# Java
+##############################################################################
+java_proto_library(
+    name = "expr_java_proto",
+    deps = [":expr_proto"],
+)
+
+java_proto_library(
+    name = "syntax_java_proto",
+    deps = [":syntax_proto"],
+)
+
+java_proto_library(
+    name = "checked_java_proto",
+    deps = [":checked_proto"],
+)
+
+java_proto_library(
+    name = "value_java_proto",
+    deps = [":value_proto"],
+)
+
+java_proto_library(
+    name = "eval_java_proto",
+    deps = [":eval_proto"],
+)
+
+java_proto_library(
+    name = "explain_java_proto",
+    deps = [":explain_proto"],
+)
+
+###############################################################################
+## Go
+###############################################################################
+
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "google_rpc_status_go_proto",
+    importpath = "google.golang.org/genproto/googleapis/rpc/status",
+    protos = ["@com_google_googleapis//google/rpc:status_proto"],
+)
+
+go_proto_library(
+    name = "expr_go_proto",
+    importpath = "cel.dev/expr",
+    protos = [":expr_proto"],
+    deps = [
+        ":google_rpc_status_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "syntax_go_proto",
+    importpath = "cel.dev/expr",
+    protos = [":syntax_proto"],
+)
+
+go_proto_library(
+    name = "checked_go_proto",
+    embed = [":syntax_go_proto"],
+    importpath = "cel.dev/expr",
+    protos = [":checked_proto"],
+)
+
+go_proto_library(
+    name = "value_go_proto",
+    importpath = "cel.dev/expr",
+    protos = [":value_proto"],
+)
+
+go_proto_library(
+    name = "eval_go_proto",
+    embed = [":value_go_proto"],
+    importpath = "cel.dev/expr",
+    protos = [":eval_proto"],
+    deps = [
+        ":google_rpc_status_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "explain_go_proto",
+    embed = [":value_go_proto"],
+    importpath = "cel.dev/expr",
+    protos = [":explain_proto"],
+)
+
+###############################################################################
+## C++
+###############################################################################
+
+# Note: cc_proto_library cannot generate a target for expr_proto due to the subtargets
+# defined below
+
+cc_proto_library(
+    name = "syntax_cc_proto",
+    deps = [":syntax_proto"],
+)
+
+cc_proto_library(
+    name = "checked_cc_proto",
+    deps = [":checked_proto"],
+)
+
+cc_proto_library(
+    name = "value_cc_proto",
+    deps = [":value_proto"],
+)
+
+cc_proto_library(
+    name = "eval_cc_proto",
+    deps = [":eval_proto"],
+)
+
+cc_proto_library(
+    name = "explain_cc_proto",
+    deps = [":explain_proto"],
+)

--- a/proto/cel/expr/checked.proto
+++ b/proto/cel/expr/checked.proto
@@ -1,0 +1,344 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "cel/expr/syntax.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "DeclProto";
+option java_package = "dev.cel.expr";
+
+// Protos for representing CEL declarations and typed checked expressions.
+
+// A CEL expression which has been successfully type checked.
+message CheckedExpr {
+  // A map from expression ids to resolved references.
+  //
+  // The following entries are in this table:
+  //
+  // - An Ident or Select expression is represented here if it resolves to a
+  //   declaration. For instance, if `a.b.c` is represented by
+  //   `select(select(id(a), b), c)`, and `a.b` resolves to a declaration,
+  //   while `c` is a field selection, then the reference is attached to the
+  //   nested select expression (but not to the id or or the outer select).
+  //   In turn, if `a` resolves to a declaration and `b.c` are field selections,
+  //   the reference is attached to the ident expression.
+  // - Every Call expression has an entry here, identifying the function being
+  //   called.
+  // - Every CreateStruct expression for a message has an entry, identifying
+  //   the message.
+  map<int64, Reference> reference_map = 2;
+
+  // A map from expression ids to types.
+  //
+  // Every expression node which has a type different than DYN has a mapping
+  // here. If an expression has type DYN, it is omitted from this map to save
+  // space.
+  map<int64, Type> type_map = 3;
+
+  // The source info derived from input that generated the parsed `expr` and
+  // any optimizations made during the type-checking pass.
+  SourceInfo source_info = 5;
+
+  // The expr version indicates the major / minor version number of the `expr`
+  // representation.
+  //
+  // The most common reason for a version change will be to indicate to the CEL
+  // runtimes that transformations have been performed on the expr during static
+  // analysis. In some cases, this will save the runtime the work of applying
+  // the same or similar transformations prior to evaluation.
+  string expr_version = 6;
+
+  // The checked expression. Semantically equivalent to the parsed `expr`, but
+  // may have structural differences.
+  Expr expr = 4;
+}
+
+// Represents a CEL type.
+message Type {
+  // List type with typed elements, e.g. `list<example.proto.MyMessage>`.
+  message ListType {
+    // The element type.
+    Type elem_type = 1;
+  }
+
+  // Map type with parameterized key and value types, e.g. `map<string, int>`.
+  message MapType {
+    // The type of the key.
+    Type key_type = 1;
+
+    // The type of the value.
+    Type value_type = 2;
+  }
+
+  // Function type with result and arg types.
+  message FunctionType {
+    // Result type of the function.
+    Type result_type = 1;
+
+    // Argument types of the function.
+    repeated Type arg_types = 2;
+  }
+
+  // Application defined abstract type.
+  message AbstractType {
+    // The fully qualified name of this abstract type.
+    string name = 1;
+
+    // Parameter types for this abstract type.
+    repeated Type parameter_types = 2;
+  }
+
+  // CEL primitive types.
+  enum PrimitiveType {
+    // Unspecified type.
+    PRIMITIVE_TYPE_UNSPECIFIED = 0;
+
+    // Boolean type.
+    BOOL = 1;
+
+    // Int64 type.
+    //
+    // 32-bit integer values are widened to int64.
+    INT64 = 2;
+
+    // Uint64 type.
+    //
+    // 32-bit unsigned integer values are widened to uint64.
+    UINT64 = 3;
+
+    // Double type.
+    //
+    // 32-bit float values are widened to double values.
+    DOUBLE = 4;
+
+    // String type.
+    STRING = 5;
+
+    // Bytes type.
+    BYTES = 6;
+  }
+
+  // Well-known protobuf types treated with first-class support in CEL.
+  enum WellKnownType {
+    // Unspecified type.
+    WELL_KNOWN_TYPE_UNSPECIFIED = 0;
+
+    // Well-known protobuf.Any type.
+    //
+    // Any types are a polymorphic message type. During type-checking they are
+    // treated like `DYN` types, but at runtime they are resolved to a specific
+    // message type specified at evaluation time.
+    ANY = 1;
+
+    // Well-known protobuf.Timestamp type, internally referenced as `timestamp`.
+    TIMESTAMP = 2;
+
+    // Well-known protobuf.Duration type, internally referenced as `duration`.
+    DURATION = 3;
+  }
+
+  // The kind of type.
+  oneof type_kind {
+    // Dynamic type.
+    google.protobuf.Empty dyn = 1;
+
+    // Null value.
+    google.protobuf.NullValue null = 2;
+
+    // Primitive types: `true`, `1u`, `-2.0`, `'string'`, `b'bytes'`.
+    PrimitiveType primitive = 3;
+
+    // Wrapper of a primitive type, e.g. `google.protobuf.Int64Value`.
+    PrimitiveType wrapper = 4;
+
+    // Well-known protobuf type such as `google.protobuf.Timestamp`.
+    WellKnownType well_known = 5;
+
+    // Parameterized list with elements of `list_type`, e.g. `list<timestamp>`.
+    ListType list_type = 6;
+
+    // Parameterized map with typed keys and values.
+    MapType map_type = 7;
+
+    // Function type.
+    FunctionType function = 8;
+
+    // Protocol buffer message type.
+    //
+    // The `message_type` string specifies the qualified message type name. For
+    // example, `google.type.PhoneNumber`.
+    string message_type = 9;
+
+    // Type param type.
+    //
+    // The `type_param` string specifies the type parameter name, e.g. `list<E>`
+    // would be a `list_type` whose element type was a `type_param` type
+    // named `E`.
+    string type_param = 10;
+
+    // Type type.
+    //
+    // The `type` value specifies the target type. e.g. int is type with a
+    // target type of `Primitive.INT64`.
+    Type type = 11;
+
+    // Error type.
+    //
+    // During type-checking if an expression is an error, its type is propagated
+    // as the `ERROR` type. This permits the type-checker to discover other
+    // errors present in the expression.
+    google.protobuf.Empty error = 12;
+
+    // Abstract, application defined type.
+    //
+    // An abstract type has no accessible field names, and it can only be
+    // inspected via helper / member functions.
+    AbstractType abstract_type = 14;
+  }
+}
+
+// Represents a declaration of a named value or function.
+//
+// A declaration is part of the contract between the expression, the agent
+// evaluating that expression, and the caller requesting evaluation.
+message Decl {
+  // Identifier declaration which specifies its type and optional `Expr` value.
+  //
+  // An identifier without a value is a declaration that must be provided at
+  // evaluation time. An identifier with a value should resolve to a constant,
+  // but may be used in conjunction with other identifiers bound at evaluation
+  // time.
+  message IdentDecl {
+    // Required. The type of the identifier.
+    Type type = 1;
+
+    // The constant value of the identifier. If not specified, the identifier
+    // must be supplied at evaluation time.
+    Constant value = 2;
+
+    // Documentation string for the identifier.
+    string doc = 3;
+  }
+
+  // Function declaration specifies one or more overloads which indicate the
+  // function's parameter types and return type.
+  //
+  // Functions have no observable side-effects (there may be side-effects like
+  // logging which are not observable from CEL).
+  message FunctionDecl {
+    // An overload indicates a function's parameter types and return type, and
+    // may optionally include a function body described in terms of
+    // [Expr][cel.expr.Expr] values.
+    //
+    // Functions overloads are declared in either a function or method
+    // call-style. For methods, the `params[0]` is the expected type of the
+    // target receiver.
+    //
+    // Overloads must have non-overlapping argument types after erasure of all
+    // parameterized type variables (similar as type erasure in Java).
+    message Overload {
+      // Required. Globally unique overload name of the function which reflects
+      // the function name and argument types.
+      //
+      // This will be used by a [Reference][cel.expr.Reference] to
+      // indicate the `overload_id` that was resolved for the function `name`.
+      string overload_id = 1;
+
+      // List of function parameter [Type][cel.expr.Type] values.
+      //
+      // Param types are disjoint after generic type parameters have been
+      // replaced with the type `DYN`. Since the `DYN` type is compatible with
+      // any other type, this means that if `A` is a type parameter, the
+      // function types `int<A>` and `int<int>` are not disjoint. Likewise,
+      // `map<string, string>` is not disjoint from `map<K, V>`.
+      //
+      // When the `result_type` of a function is a generic type param, the
+      // type param name also appears as the `type` of on at least one params.
+      repeated Type params = 2;
+
+      // The type param names associated with the function declaration.
+      //
+      // For example, `function ex<K,V>(K key, map<K, V> map) : V` would yield
+      // the type params of `K, V`.
+      repeated string type_params = 3;
+
+      // Required. The result type of the function. For example, the operator
+      // `string.isEmpty()` would have `result_type` of `kind: BOOL`.
+      Type result_type = 4;
+
+      // Whether the function is to be used in a method call-style `x.f(...)`
+      // of a function call-style `f(x, ...)`.
+      //
+      // For methods, the first parameter declaration, `params[0]` is the
+      // expected type of the target receiver.
+      bool is_instance_function = 5;
+
+      // Documentation string for the overload.
+      string doc = 6;
+    }
+
+    // Required. List of function overloads, must contain at least one overload.
+    repeated Overload overloads = 1;
+  }
+
+  // The fully qualified name of the declaration.
+  //
+  // Declarations are organized in containers and this represents the full path
+  // to the declaration in its container, as in `cel.expr.Decl`.
+  //
+  // Declarations used as
+  // [FunctionDecl.Overload][cel.expr.Decl.FunctionDecl.Overload]
+  // parameters may or may not have a name depending on whether the overload is
+  // function declaration or a function definition containing a result
+  // [Expr][cel.expr.Expr].
+  string name = 1;
+
+  // Required. The declaration kind.
+  oneof decl_kind {
+    // Identifier declaration.
+    IdentDecl ident = 2;
+
+    // Function declaration.
+    FunctionDecl function = 3;
+  }
+}
+
+// Describes a resolved reference to a declaration.
+message Reference {
+  // The fully qualified name of the declaration.
+  string name = 1;
+
+  // For references to functions, this is a list of `Overload.overload_id`
+  // values which match according to typing rules.
+  //
+  // If the list has more than one element, overload resolution among the
+  // presented candidates must happen at runtime because of dynamic types. The
+  // type checker attempts to narrow down this list as much as possible.
+  //
+  // Empty if this is not a reference to a
+  // [Decl.FunctionDecl][cel.expr.Decl.FunctionDecl].
+  repeated string overload_id = 3;
+
+  // For references to constants, this may contain the value of the
+  // constant if known at compile time.
+  Constant value = 4;
+}

--- a/proto/cel/expr/conformance/BUILD.bazel
+++ b/proto/cel/expr/conformance/BUILD.bazel
@@ -1,0 +1,137 @@
+package(default_visibility = ["//visibility:public"])
+
+##############################################################################
+# Common
+##############################################################################
+
+proto_library(
+    name = "conformance_proto",
+    srcs = [
+        "conformance_service.proto",
+        "envcheck.proto",
+        "simple.proto",
+    ],
+    strip_import_prefix = "/proto",
+    deps = [
+        "//proto/cel/expr:expr_proto",
+        "@com_google_googleapis//google/rpc:status_proto",
+    ],
+)
+
+proto_library(
+    name = "conformance_service_proto",
+    srcs = ["conformance_service.proto"],
+    strip_import_prefix = "/proto",
+    deps = [
+        "//proto/cel/expr:checked_proto",
+        "//proto/cel/expr:eval_proto",
+        "//proto/cel/expr:syntax_proto",
+        "@com_google_googleapis//google/rpc:status_proto",
+    ],
+)
+
+proto_library(
+    name = "envcheck_proto",
+    srcs = ["envcheck.proto"],
+    strip_import_prefix = "/proto",
+    deps = [
+        "//proto/cel/expr:checked_proto",
+    ],
+)
+
+proto_library(
+    name = "simple_proto",
+    srcs = ["simple.proto"],
+    strip_import_prefix = "/proto",
+    deps = [
+        "//proto/cel/expr:checked_proto",
+        "//proto/cel/expr:eval_proto",
+        "//proto/cel/expr:value_proto",
+    ],
+)
+
+##############################################################################
+# Java
+##############################################################################
+java_proto_library(
+    name = "conformance_java_proto",
+    deps = [":conformance_proto"],
+)
+
+java_proto_library(
+    name = "conformance_service_java_proto",
+    deps = [":conformance_service_proto"],
+)
+
+java_proto_library(
+    name = "envcheck_java_proto",
+    deps = [":envcheck_proto"],
+)
+
+java_proto_library(
+    name = "simple_java_proto",
+    deps = [":simple_proto"],
+)
+
+###############################################################################
+## Go
+###############################################################################
+
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "conformance_go_proto",
+    importpath = "cel.dev/expr/conformance",
+    protos = [":conformance_proto"],
+    deps = [
+        "//proto/cel/expr:expr_go_proto",
+        "//proto/cel/expr:google_rpc_status_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "conformance_service_go_proto",
+    importpath = "cel.dev/expr/conformance",
+    protos = [":conformance_service_proto"],
+    deps = [
+        "//proto/cel/expr:expr_go_proto",
+        "//proto/cel/expr:google_rpc_status_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "envcheck_go_proto",
+    importpath = "cel.dev/expr/conformance",
+    protos = [":envcheck_proto"],
+    deps = [
+        "//proto/cel/expr:expr_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "simple_go_proto",
+    importpath = "cel.dev/expr/conformance",
+    protos = [":simple_proto"],
+    deps = [
+        "//proto/cel/expr:expr_go_proto",
+    ],
+)
+
+###############################################################################
+## C++
+###############################################################################
+
+cc_proto_library(
+    name = "conformance_service_cc_proto",
+    deps = [":conformance_service_proto"],
+)
+
+cc_proto_library(
+    name = "envcheck_cc_proto",
+    deps = [":envcheck_proto"],
+)
+
+cc_proto_library(
+    name = "simple_cc_proto",
+    deps = [":simple_proto"],
+)

--- a/proto/cel/expr/conformance/conformance_service.proto
+++ b/proto/cel/expr/conformance/conformance_service.proto
@@ -1,0 +1,180 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr.conformance;
+
+import "cel/expr/checked.proto";
+import "cel/expr/eval.proto";
+import "cel/expr/syntax.proto";
+import "google/rpc/status.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr/conformance";
+option java_multiple_files = true;
+option java_outer_classname = "ConformanceServiceProto";
+option java_package = "dev.cel.expr.conformance";
+
+// Access a CEL implementation from another process or machine.
+// A CEL implementation is decomposed as a parser, a static checker,
+// and an evaluator.  Every CEL implementation is expected to provide
+// a server for this API.  The API will be used for conformance testing
+// and other utilities.
+service ConformanceService {
+  // Transforms CEL source text into a parsed representation.
+  rpc Parse(ParseRequest) returns (ParseResponse) {
+  }
+
+  // Runs static checks on a parsed CEL representation and return
+  // an annotated representation, or a set of issues.
+  rpc Check(CheckRequest) returns (CheckResponse) {
+  }
+
+  // Evaluates a parsed or annotation CEL representation given
+  // values of external bindings.
+  rpc Eval(EvalRequest) returns (EvalResponse) {
+  }
+}
+
+// Request message for the Parse method.
+message ParseRequest {
+  // Required. Source text in CEL syntax.
+  string cel_source = 1;
+
+  // Tag for version of CEL syntax, for future use.
+  string syntax_version = 2;
+
+  // File or resource for source text, used in [SourceInfo][google.api.SourceInfo].
+  string source_location = 3;
+
+  // Prevent macro expansion.  See "Macros" in Language Defiinition.
+  bool disable_macros = 4;
+}
+
+// Response message for the Parse method.
+message ParseResponse {
+  // The parsed representation, or unset if parsing failed.
+  cel.expr.ParsedExpr parsed_expr = 1;
+
+  // Any number of issues with [StatusDetails][] as the details.
+  repeated google.rpc.Status issues = 2;
+}
+
+// Request message for the Check method.
+message CheckRequest {
+  // Required. The parsed representation of the CEL program.
+  cel.expr.ParsedExpr parsed_expr = 1;
+
+  // Declarations of types for external variables and functions.
+  // Required if program uses external variables or functions
+  // not in the default environment.
+  repeated cel.expr.Decl type_env = 2;
+
+  // The protocol buffer context.  See "Name Resolution" in the
+  // Language Definition.
+  string container = 3;
+
+  // If true, use only the declarations in [type_env][google.api.expr.conformance.v1alpha1.CheckRequest.type_env].  If false (default),
+  // add declarations for the standard definitions to the type environment.  See
+  // "Standard Definitions" in the Language Definition.
+  bool no_std_env = 4;
+}
+
+// Response message for the Check method.
+message CheckResponse {
+  // The annotated representation, or unset if checking failed.
+  cel.expr.CheckedExpr checked_expr = 1;
+
+  // Any number of issues with [StatusDetails][] as the details.
+  repeated google.rpc.Status issues = 2;
+}
+
+// Request message for the Eval method.
+message EvalRequest {
+  // Required. Either the parsed or annotated representation of the CEL program.
+  oneof expr_kind {
+    // Evaluate based on the parsed representation.
+    cel.expr.ParsedExpr parsed_expr = 1;
+
+    // Evaluate based on the checked representation.
+    cel.expr.CheckedExpr checked_expr = 2;
+  }
+
+  // Bindings for the external variables.  The types SHOULD be compatible
+  // with the type environment in [CheckRequest][google.api.expr.conformance.v1alpha1.CheckRequest], if checked.
+  map<string, cel.expr.ExprValue> bindings = 3;
+
+  // SHOULD be the same container as used in [CheckRequest][google.api.expr.conformance.v1alpha1.CheckRequest], if checked.
+  string container = 4;
+}
+
+// Response message for the Eval method.
+message EvalResponse {
+  // The execution result, or unset if execution couldn't start.
+  cel.expr.ExprValue result = 1;
+
+  // Any number of issues with [StatusDetails][] as the details.
+  // Note that CEL execution errors are reified into [ExprValue][].
+  // Nevertheless, we'll allow out-of-band issues to be raised,
+  // which also makes the replies more regular.
+  repeated google.rpc.Status issues = 2;
+}
+
+// A specific position in source.
+message SourcePosition {
+  // The source location name (e.g. file name).
+  string location = 1;
+
+  // The UTF-8 code unit offset.
+  int32 offset = 2;
+
+  // The 1-based index of the starting line in the source text
+  // where the issue occurs, or 0 if unknown.
+  int32 line = 3;
+
+  // The 0-based index of the starting position within the line of source text
+  // where the issue occurs.  Only meaningful if line is nonzero.
+  int32 column = 4;
+}
+
+// Warnings or errors in service execution are represented by
+// [google.rpc.Status][google.rpc.Status] messages, with the following message
+// in the details field.
+message IssueDetails {
+  // Severities of issues.
+  enum Severity {
+    // An unspecified severity.
+    SEVERITY_UNSPECIFIED = 0;
+
+    // Deprecation issue for statements and method that may no longer be
+    // supported or maintained.
+    DEPRECATION = 1;
+
+    // Warnings such as: unused variables.
+    WARNING = 2;
+
+    // Errors such as: unmatched curly braces or variable redefinition.
+    ERROR = 3;
+  }
+
+  // The severity of the issue.
+  Severity severity = 1;
+
+  // Position in the source, if known.
+  SourcePosition position = 2;
+
+  // Expression ID from [Expr][], 0 if unknown.
+  int64 id = 3;
+}

--- a/proto/cel/expr/conformance/envcheck.proto
+++ b/proto/cel/expr/conformance/envcheck.proto
@@ -1,0 +1,37 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for runtime support of standard functions.
+
+syntax = "proto3";
+
+package cel.expr.conformance;
+
+import "cel/expr/checked.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr/conformance";
+option java_multiple_files = true;
+option java_outer_classname = "EnvcheckProto";
+option java_package = "dev.cel.expr.conformance";
+
+// The format of a standard environment, i.e. a collection of declarations
+// for the checker.
+message Env {
+  // Required.  The name of the environment.
+  string name = 1;
+
+  // The declarations in this environment.
+  repeated cel.expr.Decl decl = 2;
+}

--- a/proto/cel/expr/conformance/proto2/BUILD.bazel
+++ b/proto/cel/expr/conformance/proto2/BUILD.bazel
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+##############################################################################
+# Common
+##############################################################################
+
+proto_library(
+    name = "test_all_types_proto",
+    srcs = ["test_all_types.proto"],
+    strip_import_prefix = "/proto",
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+##############################################################################
+# Java
+##############################################################################
+java_proto_library(
+    name = "test_all_types_java_proto",
+    deps = [":test_all_types_proto"],
+)
+
+###############################################################################
+## Go
+###############################################################################
+
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "test_all_types_go_proto",
+    importpath = "cel.dev/expr/conformance/proto2",
+    protos = [":test_all_types_proto"],
+)
+
+###############################################################################
+## C++
+###############################################################################
+
+cc_proto_library(
+    name = "test_all_types_cc_proto",
+    deps = [":test_all_types_proto"],
+)

--- a/proto/cel/expr/conformance/proto2/test_all_types.proto
+++ b/proto/cel/expr/conformance/proto2/test_all_types.proto
@@ -1,0 +1,307 @@
+syntax = "proto2";
+
+package cel.expr.conformance.proto2;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr/conformance/proto2";
+option java_multiple_files = true;
+option java_outer_classname = "TestAllTypesProto";
+option java_package = "dev.cel.expr.conformance.proto2";
+
+// This proto includes every type of field in both singular and repeated
+// forms.
+message TestAllTypes {
+  message NestedMessage {
+    // The field name "b" fails to compile in proto1 because it conflicts with
+    // a local variable named "b" in one of the generated methods.
+    // This file needs to compile in proto1 to test backwards-compatibility.
+    optional int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  // Singular
+  optional int32 single_int32 = 1 [default = -32];
+  optional int64 single_int64 = 2 [default = -64];
+  optional uint32 single_uint32 = 3 [default = 32];
+  optional uint64 single_uint64 = 4 [default = 64];
+  optional sint32 single_sint32 = 5;
+  optional sint64 single_sint64 = 6;
+  optional fixed32 single_fixed32 = 7;
+  optional fixed64 single_fixed64 = 8;
+  optional sfixed32 single_sfixed32 = 9;
+  optional sfixed64 single_sfixed64 = 10;
+  optional float single_float = 11 [default = 3.0];
+  optional double single_double = 12 [default = 6.4];
+  optional bool single_bool = 13 [default = true];
+  optional string single_string = 14 [default = "empty"];
+  optional bytes single_bytes = 15 [default = "none"];
+
+  // Wellknown.
+  optional google.protobuf.Any single_any = 100;
+  optional google.protobuf.Duration single_duration = 101;
+  optional google.protobuf.Timestamp single_timestamp = 102;
+  optional google.protobuf.Struct single_struct = 103;
+  optional google.protobuf.Value single_value = 104;
+  optional google.protobuf.Int64Value single_int64_wrapper = 105;
+  optional google.protobuf.Int32Value single_int32_wrapper = 106;
+  optional google.protobuf.DoubleValue single_double_wrapper = 107;
+  optional google.protobuf.FloatValue single_float_wrapper = 108;
+  optional google.protobuf.UInt64Value single_uint64_wrapper = 109;
+  optional google.protobuf.UInt32Value single_uint32_wrapper = 110;
+  optional google.protobuf.StringValue single_string_wrapper = 111;
+  optional google.protobuf.BoolValue single_bool_wrapper = 112;
+  optional google.protobuf.BytesValue single_bytes_wrapper = 113;
+  optional google.protobuf.ListValue list_value = 114;
+  optional google.protobuf.NullValue null_value = 115;
+  optional google.protobuf.NullValue optional_null_value = 116;
+
+  // Nested messages
+  oneof nested_type {
+    NestedMessage single_nested_message = 21;
+    NestedEnum single_nested_enum = 22 [default = BAR];
+  }
+  optional NestedMessage standalone_message = 23;
+  optional NestedEnum standalone_enum = 24;
+
+  // Repeated
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+
+  // Repeated and nested
+  repeated NestedMessage repeated_nested_message = 51;
+  repeated NestedEnum repeated_nested_enum = 52;
+  repeated string repeated_string_piece = 53 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 54 [ctype = CORD];
+  repeated NestedMessage repeated_lazy_message = 55 [lazy = true];
+
+  // Repeated wellknown.
+  repeated google.protobuf.Any repeated_any = 120;
+  repeated google.protobuf.Duration repeated_duration = 121;
+  repeated google.protobuf.Timestamp repeated_timestamp = 122;
+  repeated google.protobuf.Struct repeated_struct = 123;
+  repeated google.protobuf.Value repeated_value = 124;
+  repeated google.protobuf.Int64Value repeated_int64_wrapper = 125;
+  repeated google.protobuf.Int32Value repeated_int32_wrapper = 126;
+  repeated google.protobuf.DoubleValue repeated_double_wrapper = 127;
+  repeated google.protobuf.FloatValue repeated_float_wrapper = 128;
+  repeated google.protobuf.UInt64Value repeated_uint64_wrapper = 129;
+  repeated google.protobuf.UInt32Value repeated_uint32_wrapper = 130;
+  repeated google.protobuf.StringValue repeated_string_wrapper = 131;
+  repeated google.protobuf.BoolValue repeated_bool_wrapper = 132;
+  repeated google.protobuf.BytesValue repeated_bytes_wrapper = 133;
+  repeated google.protobuf.ListValue repeated_list_value = 134;
+  repeated google.protobuf.NullValue repeated_null_value = 135;
+
+  // Map
+  map<int64, NestedTestAllTypes> map_int64_nested_type = 62;
+
+  map<bool, bool> map_bool_bool = 63;
+  map<bool, string> map_bool_string = 64;
+  map<bool, bytes> map_bool_bytes = 65;
+  map<bool, int32> map_bool_int32 = 66;
+  map<bool, int64> map_bool_int64 = 67;
+  map<bool, uint32> map_bool_uint32 = 68;
+  map<bool, uint64> map_bool_uint64 = 69;
+  map<bool, float> map_bool_float = 70;
+  map<bool, double> map_bool_double = 71;
+  map<bool, NestedEnum> map_bool_enum = 72;
+  map<bool, NestedMessage> map_bool_message = 73;
+  map<bool, google.protobuf.Duration> map_bool_duration = 228;
+  map<bool, google.protobuf.Timestamp> map_bool_timestamp = 229;
+  map<bool, google.protobuf.NullValue> map_bool_null_value = 230;
+  map<bool, google.protobuf.Any> map_bool_any = 246;
+  map<bool, google.protobuf.Struct> map_bool_struct = 247;
+  map<bool, google.protobuf.Value> map_bool_value = 248;
+  map<bool, google.protobuf.ListValue> map_bool_list_value = 249;
+  map<bool, google.protobuf.Int64Value> map_bool_int64_wrapper = 250;
+  map<bool, google.protobuf.Int32Value> map_bool_int32_wrapper = 251;
+  map<bool, google.protobuf.DoubleValue> map_bool_double_wrapper = 252;
+  map<bool, google.protobuf.FloatValue> map_bool_float_wrapper = 253;
+  map<bool, google.protobuf.UInt64Value> map_bool_uint64_wrapper = 254;
+  map<bool, google.protobuf.UInt32Value> map_bool_uint32_wrapper = 255;
+  map<bool, google.protobuf.StringValue> map_bool_string_wrapper = 256;
+  map<bool, google.protobuf.BoolValue> map_bool_bool_wrapper = 257;
+  map<bool, google.protobuf.BytesValue> map_bool_bytes_wrapper = 258;
+
+  map<int32, bool> map_int32_bool = 74;
+  map<int32, string> map_int32_string = 75;
+  map<int32, bytes> map_int32_bytes = 76;
+  map<int32, int32> map_int32_int32 = 77;
+  map<int32, int64> map_int32_int64 = 78;
+  map<int32, uint32> map_int32_uint32 = 79;
+  map<int32, uint64> map_int32_uint64 = 80;
+  map<int32, float> map_int32_float = 81;
+  map<int32, double> map_int32_double = 82;
+  map<int32, NestedEnum> map_int32_enum = 83;
+  map<int32, NestedMessage> map_int32_message = 84;
+  map<int32, google.protobuf.Duration> map_int32_duration = 231;
+  map<int32, google.protobuf.Timestamp> map_int32_timestamp = 232;
+  map<int32, google.protobuf.NullValue> map_int32_null_value = 233;
+  map<int32, google.protobuf.Any> map_int32_any = 259;
+  map<int32, google.protobuf.Struct> map_int32_struct = 260;
+  map<int32, google.protobuf.Value> map_int32_value = 261;
+  map<int32, google.protobuf.ListValue> map_int32_list_value = 262;
+  map<int32, google.protobuf.Int64Value> map_int32_int64_wrapper = 263;
+  map<int32, google.protobuf.Int32Value> map_int32_int32_wrapper = 264;
+  map<int32, google.protobuf.DoubleValue> map_int32_double_wrapper = 265;
+  map<int32, google.protobuf.FloatValue> map_int32_float_wrapper = 266;
+  map<int32, google.protobuf.UInt64Value> map_int32_uint64_wrapper = 267;
+  map<int32, google.protobuf.UInt32Value> map_int32_uint32_wrapper = 268;
+  map<int32, google.protobuf.StringValue> map_int32_string_wrapper = 269;
+  map<int32, google.protobuf.BoolValue> map_int32_bool_wrapper = 270;
+  map<int32, google.protobuf.BytesValue> map_int32_bytes_wrapper = 271;
+
+  map<int64, bool> map_int64_bool = 85;
+  map<int64, string> map_int64_string = 86;
+  map<int64, bytes> map_int64_bytes = 87;
+  map<int64, int32> map_int64_int32 = 88;
+  map<int64, int64> map_int64_int64 = 89;
+  map<int64, uint32> map_int64_uint32 = 90;
+  map<int64, uint64> map_int64_uint64 = 91;
+  map<int64, float> map_int64_float = 92;
+  map<int64, double> map_int64_double = 93;
+  map<int64, NestedEnum> map_int64_enum = 94;
+  map<int64, NestedMessage> map_int64_message = 95;
+  map<int64, google.protobuf.Duration> map_int64_duration = 234;
+  map<int64, google.protobuf.Timestamp> map_int64_timestamp = 235;
+  map<int64, google.protobuf.NullValue> map_int64_null_value = 236;
+  map<int64, google.protobuf.Any> map_int64_any = 272;
+  map<int64, google.protobuf.Struct> map_int64_struct = 273;
+  map<int64, google.protobuf.Value> map_int64_value = 274;
+  map<int64, google.protobuf.ListValue> map_int64_list_value = 275;
+  map<int64, google.protobuf.Int64Value> map_int64_int64_wrapper = 276;
+  map<int64, google.protobuf.Int32Value> map_int64_int32_wrapper = 277;
+  map<int64, google.protobuf.DoubleValue> map_int64_double_wrapper = 278;
+  map<int64, google.protobuf.FloatValue> map_int64_float_wrapper = 279;
+  map<int64, google.protobuf.UInt64Value> map_int64_uint64_wrapper = 280;
+  map<int64, google.protobuf.UInt32Value> map_int64_uint32_wrapper = 281;
+  map<int64, google.protobuf.StringValue> map_int64_string_wrapper = 282;
+  map<int64, google.protobuf.BoolValue> map_int64_bool_wrapper = 283;
+  map<int64, google.protobuf.BytesValue> map_int64_bytes_wrapper = 284;
+
+  map<uint32, bool> map_uint32_bool = 96;
+  map<uint32, string> map_uint32_string = 97;
+  map<uint32, bytes> map_uint32_bytes = 98;
+  map<uint32, int32> map_uint32_int32 = 99;
+  map<uint32, int64> map_uint32_int64 = 200;
+  map<uint32, uint32> map_uint32_uint32 = 201;
+  map<uint32, uint64> map_uint32_uint64 = 202;
+  map<uint32, float> map_uint32_float = 203;
+  map<uint32, double> map_uint32_double = 204;
+  map<uint32, NestedEnum> map_uint32_enum = 205;
+  map<uint32, NestedMessage> map_uint32_message = 206;
+  map<uint32, google.protobuf.Duration> map_uint32_duration = 237;
+  map<uint32, google.protobuf.Timestamp> map_uint32_timestamp = 238;
+  map<uint32, google.protobuf.NullValue> map_uint32_null_value = 239;
+  map<uint32, google.protobuf.Any> map_uint32_any = 285;
+  map<uint32, google.protobuf.Struct> map_uint32_struct = 286;
+  map<uint32, google.protobuf.Value> map_uint32_value = 287;
+  map<uint32, google.protobuf.ListValue> map_uint32_list_value = 288;
+  map<uint32, google.protobuf.Int64Value> map_uint32_int64_wrapper = 289;
+  map<uint32, google.protobuf.Int32Value> map_uint32_int32_wrapper = 290;
+  map<uint32, google.protobuf.DoubleValue> map_uint32_double_wrapper = 291;
+  map<uint32, google.protobuf.FloatValue> map_uint32_float_wrapper = 292;
+  map<uint32, google.protobuf.UInt64Value> map_uint32_uint64_wrapper = 293;
+  map<uint32, google.protobuf.UInt32Value> map_uint32_uint32_wrapper = 294;
+  map<uint32, google.protobuf.StringValue> map_uint32_string_wrapper = 295;
+  map<uint32, google.protobuf.BoolValue> map_uint32_bool_wrapper = 296;
+  map<uint32, google.protobuf.BytesValue> map_uint32_bytes_wrapper = 297;
+
+  map<uint64, bool> map_uint64_bool = 207;
+  map<uint64, string> map_uint64_string = 208;
+  map<uint64, bytes> map_uint64_bytes = 209;
+  map<uint64, int32> map_uint64_int32 = 210;
+  map<uint64, int64> map_uint64_int64 = 211;
+  map<uint64, uint32> map_uint64_uint32 = 212;
+  map<uint64, uint64> map_uint64_uint64 = 213;
+  map<uint64, float> map_uint64_float = 214;
+  map<uint64, double> map_uint64_double = 215;
+  map<uint64, NestedEnum> map_uint64_enum = 216;
+  map<uint64, NestedMessage> map_uint64_message = 217;
+  map<uint64, google.protobuf.Duration> map_uint64_duration = 240;
+  map<uint64, google.protobuf.Timestamp> map_uint64_timestamp = 241;
+  map<uint64, google.protobuf.NullValue> map_uint64_null_value = 242;
+  map<uint64, google.protobuf.Any> map_uint64_any = 298;
+  map<uint64, google.protobuf.Struct> map_uint64_struct = 299;
+  map<uint64, google.protobuf.Value> map_uint64_value = 300;
+  map<uint64, google.protobuf.ListValue> map_uint64_list_value = 301;
+  map<uint64, google.protobuf.Int64Value> map_uint64_int64_wrapper = 302;
+  map<uint64, google.protobuf.Int32Value> map_uint64_int32_wrapper = 303;
+  map<uint64, google.protobuf.DoubleValue> map_uint64_double_wrapper = 304;
+  map<uint64, google.protobuf.FloatValue> map_uint64_float_wrapper = 305;
+  map<uint64, google.protobuf.UInt64Value> map_uint64_uint64_wrapper = 306;
+  map<uint64, google.protobuf.UInt32Value> map_uint64_uint32_wrapper = 307;
+  map<uint64, google.protobuf.StringValue> map_uint64_string_wrapper = 308;
+  map<uint64, google.protobuf.BoolValue> map_uint64_bool_wrapper = 309;
+  map<uint64, google.protobuf.BytesValue> map_uint64_bytes_wrapper = 310;
+
+  map<string, bool> map_string_bool = 218;
+  map<string, string> map_string_string = 61;
+  map<string, bytes> map_string_bytes = 219;
+  map<string, int32> map_string_int32 = 220;
+  map<string, int64> map_string_int64 = 221;
+  map<string, uint32> map_string_uint32 = 222;
+  map<string, uint64> map_string_uint64 = 223;
+  map<string, float> map_string_float = 224;
+  map<string, double> map_string_double = 225;
+  map<string, NestedEnum> map_string_enum = 226;
+  map<string, NestedMessage> map_string_message = 227;
+  map<string, google.protobuf.Duration> map_string_duration = 243;
+  map<string, google.protobuf.Timestamp> map_string_timestamp = 244;
+  map<string, google.protobuf.NullValue> map_string_null_value = 245;
+  map<string, google.protobuf.Any> map_string_any = 311;
+  map<string, google.protobuf.Struct> map_string_struct = 312;
+  map<string, google.protobuf.Value> map_string_value = 313;
+  map<string, google.protobuf.ListValue> map_string_list_value = 314;
+  map<string, google.protobuf.Int64Value> map_string_int64_wrapper = 315;
+  map<string, google.protobuf.Int32Value> map_string_int32_wrapper = 316;
+  map<string, google.protobuf.DoubleValue> map_string_double_wrapper = 317;
+  map<string, google.protobuf.FloatValue> map_string_float_wrapper = 318;
+  map<string, google.protobuf.UInt64Value> map_string_uint64_wrapper = 319;
+  map<string, google.protobuf.UInt32Value> map_string_uint32_wrapper = 320;
+  map<string, google.protobuf.StringValue> map_string_string_wrapper = 321;
+  map<string, google.protobuf.BoolValue> map_string_bool_wrapper = 322;
+  map<string, google.protobuf.BytesValue> map_string_bytes_wrapper = 323;
+}
+
+// This proto includes a recursively nested message.
+message NestedTestAllTypes {
+  optional NestedTestAllTypes child = 1;
+  optional TestAllTypes payload = 2;
+}
+
+// This proto has a required field.
+message TestRequired {
+  required int32 required_int32 = 1;
+}
+
+// This proto tests that global enums are resolved correctly.
+enum GlobalEnum {
+  GOO = 0;
+  GAR = 1;
+  GAZ = 2;
+}

--- a/proto/cel/expr/conformance/proto3/BUILD.bazel
+++ b/proto/cel/expr/conformance/proto3/BUILD.bazel
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+##############################################################################
+# Common
+##############################################################################
+
+proto_library(
+    name = "test_all_types_proto",
+    srcs = ["test_all_types.proto"],
+    strip_import_prefix = "/proto",
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+##############################################################################
+# Java
+##############################################################################
+java_proto_library(
+    name = "test_all_types_java_proto",
+    deps = [":test_all_types_proto"],
+)
+
+###############################################################################
+## Go
+###############################################################################
+
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "test_all_types_go_proto",
+    importpath = "cel.dev/expr/conformance/proto3",
+    protos = [":test_all_types_proto"],
+)
+
+###############################################################################
+## C++
+###############################################################################
+
+cc_proto_library(
+    name = "test_all_types_cc_proto",
+    deps = [":test_all_types_proto"],
+)

--- a/proto/cel/expr/conformance/proto3/test_all_types.proto
+++ b/proto/cel/expr/conformance/proto3/test_all_types.proto
@@ -1,0 +1,302 @@
+syntax = "proto3";
+
+package cel.expr.conformance.proto3;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr/conformance/proto3";
+option java_multiple_files = true;
+option java_outer_classname = "TestAllTypesProto";
+option java_package = "dev.cel.expr.conformance.proto3";
+
+// This proto includes every type of field in both singular and repeated
+// forms.
+message TestAllTypes {
+  message NestedMessage {
+    // The field name "b" fails to compile in proto1 because it conflicts with
+    // a local variable named "b" in one of the generated methods.
+    // This file needs to compile in proto1 to test backwards-compatibility.
+    int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  // Singular
+  int32 single_int32 = 1;
+  int64 single_int64 = 2;
+  uint32 single_uint32 = 3;
+  uint64 single_uint64 = 4;
+  sint32 single_sint32 = 5;
+  sint64 single_sint64 = 6;
+  fixed32 single_fixed32 = 7;
+  fixed64 single_fixed64 = 8;
+  sfixed32 single_sfixed32 = 9;
+  sfixed64 single_sfixed64 = 10;
+  float single_float = 11;
+  double single_double = 12;
+  bool single_bool = 13;
+  string single_string = 14;
+  bytes single_bytes = 15;
+
+  // Wellknown.
+  google.protobuf.Any single_any = 100;
+  google.protobuf.Duration single_duration = 101;
+  google.protobuf.Timestamp single_timestamp = 102;
+  google.protobuf.Struct single_struct = 103;
+  google.protobuf.Value single_value = 104;
+  google.protobuf.Int64Value single_int64_wrapper = 105;
+  google.protobuf.Int32Value single_int32_wrapper = 106;
+  google.protobuf.DoubleValue single_double_wrapper = 107;
+  google.protobuf.FloatValue single_float_wrapper = 108;
+  google.protobuf.UInt64Value single_uint64_wrapper = 109;
+  google.protobuf.UInt32Value single_uint32_wrapper = 110;
+  google.protobuf.StringValue single_string_wrapper = 111;
+  google.protobuf.BoolValue single_bool_wrapper = 112;
+  google.protobuf.BytesValue single_bytes_wrapper = 113;
+  google.protobuf.ListValue list_value = 114;
+  google.protobuf.NullValue null_value = 115;
+  optional google.protobuf.NullValue optional_null_value = 116;
+
+  // Nested messages
+  oneof nested_type {
+    NestedMessage single_nested_message = 21;
+    NestedEnum single_nested_enum = 22;
+  }
+  NestedMessage standalone_message = 23;
+  NestedEnum standalone_enum = 24;
+
+  // Repeated
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+
+  // Repeated and nested
+  repeated NestedMessage repeated_nested_message = 51;
+  repeated NestedEnum repeated_nested_enum = 52;
+  repeated string repeated_string_piece = 53 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 54 [ctype = CORD];
+  repeated NestedMessage repeated_lazy_message = 55 [lazy = true];
+
+  // Repeated wellknown.
+  repeated google.protobuf.Any repeated_any = 120;
+  repeated google.protobuf.Duration repeated_duration = 121;
+  repeated google.protobuf.Timestamp repeated_timestamp = 122;
+  repeated google.protobuf.Struct repeated_struct = 123;
+  repeated google.protobuf.Value repeated_value = 124;
+  repeated google.protobuf.Int64Value repeated_int64_wrapper = 125;
+  repeated google.protobuf.Int32Value repeated_int32_wrapper = 126;
+  repeated google.protobuf.DoubleValue repeated_double_wrapper = 127;
+  repeated google.protobuf.FloatValue repeated_float_wrapper = 128;
+  repeated google.protobuf.UInt64Value repeated_uint64_wrapper = 129;
+  repeated google.protobuf.UInt32Value repeated_uint32_wrapper = 130;
+  repeated google.protobuf.StringValue repeated_string_wrapper = 131;
+  repeated google.protobuf.BoolValue repeated_bool_wrapper = 132;
+  repeated google.protobuf.BytesValue repeated_bytes_wrapper = 133;
+  repeated google.protobuf.ListValue repeated_list_value = 134;
+  repeated google.protobuf.NullValue repeated_null_value = 135;
+
+  // Map
+  map<int64, NestedTestAllTypes> map_int64_nested_type = 62;
+
+  map<bool, bool> map_bool_bool = 63;
+  map<bool, string> map_bool_string = 64;
+  map<bool, bytes> map_bool_bytes = 65;
+  map<bool, int32> map_bool_int32 = 66;
+  map<bool, int64> map_bool_int64 = 67;
+  map<bool, uint32> map_bool_uint32 = 68;
+  map<bool, uint64> map_bool_uint64 = 69;
+  map<bool, float> map_bool_float = 70;
+  map<bool, double> map_bool_double = 71;
+  map<bool, NestedEnum> map_bool_enum = 72;
+  map<bool, NestedMessage> map_bool_message = 73;
+  map<bool, google.protobuf.Duration> map_bool_duration = 228;
+  map<bool, google.protobuf.Timestamp> map_bool_timestamp = 229;
+  map<bool, google.protobuf.NullValue> map_bool_null_value = 230;
+  map<bool, google.protobuf.Any> map_bool_any = 246;
+  map<bool, google.protobuf.Struct> map_bool_struct = 247;
+  map<bool, google.protobuf.Value> map_bool_value = 248;
+  map<bool, google.protobuf.ListValue> map_bool_list_value = 249;
+  map<bool, google.protobuf.Int64Value> map_bool_int64_wrapper = 250;
+  map<bool, google.protobuf.Int32Value> map_bool_int32_wrapper = 251;
+  map<bool, google.protobuf.DoubleValue> map_bool_double_wrapper = 252;
+  map<bool, google.protobuf.FloatValue> map_bool_float_wrapper = 253;
+  map<bool, google.protobuf.UInt64Value> map_bool_uint64_wrapper = 254;
+  map<bool, google.protobuf.UInt32Value> map_bool_uint32_wrapper = 255;
+  map<bool, google.protobuf.StringValue> map_bool_string_wrapper = 256;
+  map<bool, google.protobuf.BoolValue> map_bool_bool_wrapper = 257;
+  map<bool, google.protobuf.BytesValue> map_bool_bytes_wrapper = 258;
+
+  map<int32, bool> map_int32_bool = 74;
+  map<int32, string> map_int32_string = 75;
+  map<int32, bytes> map_int32_bytes = 76;
+  map<int32, int32> map_int32_int32 = 77;
+  map<int32, int64> map_int32_int64 = 78;
+  map<int32, uint32> map_int32_uint32 = 79;
+  map<int32, uint64> map_int32_uint64 = 80;
+  map<int32, float> map_int32_float = 81;
+  map<int32, double> map_int32_double = 82;
+  map<int32, NestedEnum> map_int32_enum = 83;
+  map<int32, NestedMessage> map_int32_message = 84;
+  map<int32, google.protobuf.Duration> map_int32_duration = 231;
+  map<int32, google.protobuf.Timestamp> map_int32_timestamp = 232;
+  map<int32, google.protobuf.NullValue> map_int32_null_value = 233;
+  map<int32, google.protobuf.Any> map_int32_any = 259;
+  map<int32, google.protobuf.Struct> map_int32_struct = 260;
+  map<int32, google.protobuf.Value> map_int32_value = 261;
+  map<int32, google.protobuf.ListValue> map_int32_list_value = 262;
+  map<int32, google.protobuf.Int64Value> map_int32_int64_wrapper = 263;
+  map<int32, google.protobuf.Int32Value> map_int32_int32_wrapper = 264;
+  map<int32, google.protobuf.DoubleValue> map_int32_double_wrapper = 265;
+  map<int32, google.protobuf.FloatValue> map_int32_float_wrapper = 266;
+  map<int32, google.protobuf.UInt64Value> map_int32_uint64_wrapper = 267;
+  map<int32, google.protobuf.UInt32Value> map_int32_uint32_wrapper = 268;
+  map<int32, google.protobuf.StringValue> map_int32_string_wrapper = 269;
+  map<int32, google.protobuf.BoolValue> map_int32_bool_wrapper = 270;
+  map<int32, google.protobuf.BytesValue> map_int32_bytes_wrapper = 271;
+
+  map<int64, bool> map_int64_bool = 85;
+  map<int64, string> map_int64_string = 86;
+  map<int64, bytes> map_int64_bytes = 87;
+  map<int64, int32> map_int64_int32 = 88;
+  map<int64, int64> map_int64_int64 = 89;
+  map<int64, uint32> map_int64_uint32 = 90;
+  map<int64, uint64> map_int64_uint64 = 91;
+  map<int64, float> map_int64_float = 92;
+  map<int64, double> map_int64_double = 93;
+  map<int64, NestedEnum> map_int64_enum = 94;
+  map<int64, NestedMessage> map_int64_message = 95;
+  map<int64, google.protobuf.Duration> map_int64_duration = 234;
+  map<int64, google.protobuf.Timestamp> map_int64_timestamp = 235;
+  map<int64, google.protobuf.NullValue> map_int64_null_value = 236;
+  map<int64, google.protobuf.Any> map_int64_any = 272;
+  map<int64, google.protobuf.Struct> map_int64_struct = 273;
+  map<int64, google.protobuf.Value> map_int64_value = 274;
+  map<int64, google.protobuf.ListValue> map_int64_list_value = 275;
+  map<int64, google.protobuf.Int64Value> map_int64_int64_wrapper = 276;
+  map<int64, google.protobuf.Int32Value> map_int64_int32_wrapper = 277;
+  map<int64, google.protobuf.DoubleValue> map_int64_double_wrapper = 278;
+  map<int64, google.protobuf.FloatValue> map_int64_float_wrapper = 279;
+  map<int64, google.protobuf.UInt64Value> map_int64_uint64_wrapper = 280;
+  map<int64, google.protobuf.UInt32Value> map_int64_uint32_wrapper = 281;
+  map<int64, google.protobuf.StringValue> map_int64_string_wrapper = 282;
+  map<int64, google.protobuf.BoolValue> map_int64_bool_wrapper = 283;
+  map<int64, google.protobuf.BytesValue> map_int64_bytes_wrapper = 284;
+
+  map<uint32, bool> map_uint32_bool = 96;
+  map<uint32, string> map_uint32_string = 97;
+  map<uint32, bytes> map_uint32_bytes = 98;
+  map<uint32, int32> map_uint32_int32 = 99;
+  map<uint32, int64> map_uint32_int64 = 200;
+  map<uint32, uint32> map_uint32_uint32 = 201;
+  map<uint32, uint64> map_uint32_uint64 = 202;
+  map<uint32, float> map_uint32_float = 203;
+  map<uint32, double> map_uint32_double = 204;
+  map<uint32, NestedEnum> map_uint32_enum = 205;
+  map<uint32, NestedMessage> map_uint32_message = 206;
+  map<uint32, google.protobuf.Duration> map_uint32_duration = 237;
+  map<uint32, google.protobuf.Timestamp> map_uint32_timestamp = 238;
+  map<uint32, google.protobuf.NullValue> map_uint32_null_value = 239;
+  map<uint32, google.protobuf.Any> map_uint32_any = 285;
+  map<uint32, google.protobuf.Struct> map_uint32_struct = 286;
+  map<uint32, google.protobuf.Value> map_uint32_value = 287;
+  map<uint32, google.protobuf.ListValue> map_uint32_list_value = 288;
+  map<uint32, google.protobuf.Int64Value> map_uint32_int64_wrapper = 289;
+  map<uint32, google.protobuf.Int32Value> map_uint32_int32_wrapper = 290;
+  map<uint32, google.protobuf.DoubleValue> map_uint32_double_wrapper = 291;
+  map<uint32, google.protobuf.FloatValue> map_uint32_float_wrapper = 292;
+  map<uint32, google.protobuf.UInt64Value> map_uint32_uint64_wrapper = 293;
+  map<uint32, google.protobuf.UInt32Value> map_uint32_uint32_wrapper = 294;
+  map<uint32, google.protobuf.StringValue> map_uint32_string_wrapper = 295;
+  map<uint32, google.protobuf.BoolValue> map_uint32_bool_wrapper = 296;
+  map<uint32, google.protobuf.BytesValue> map_uint32_bytes_wrapper = 297;
+
+  map<uint64, bool> map_uint64_bool = 207;
+  map<uint64, string> map_uint64_string = 208;
+  map<uint64, bytes> map_uint64_bytes = 209;
+  map<uint64, int32> map_uint64_int32 = 210;
+  map<uint64, int64> map_uint64_int64 = 211;
+  map<uint64, uint32> map_uint64_uint32 = 212;
+  map<uint64, uint64> map_uint64_uint64 = 213;
+  map<uint64, float> map_uint64_float = 214;
+  map<uint64, double> map_uint64_double = 215;
+  map<uint64, NestedEnum> map_uint64_enum = 216;
+  map<uint64, NestedMessage> map_uint64_message = 217;
+  map<uint64, google.protobuf.Duration> map_uint64_duration = 240;
+  map<uint64, google.protobuf.Timestamp> map_uint64_timestamp = 241;
+  map<uint64, google.protobuf.NullValue> map_uint64_null_value = 242;
+  map<uint64, google.protobuf.Any> map_uint64_any = 298;
+  map<uint64, google.protobuf.Struct> map_uint64_struct = 299;
+  map<uint64, google.protobuf.Value> map_uint64_value = 300;
+  map<uint64, google.protobuf.ListValue> map_uint64_list_value = 301;
+  map<uint64, google.protobuf.Int64Value> map_uint64_int64_wrapper = 302;
+  map<uint64, google.protobuf.Int32Value> map_uint64_int32_wrapper = 303;
+  map<uint64, google.protobuf.DoubleValue> map_uint64_double_wrapper = 304;
+  map<uint64, google.protobuf.FloatValue> map_uint64_float_wrapper = 305;
+  map<uint64, google.protobuf.UInt64Value> map_uint64_uint64_wrapper = 306;
+  map<uint64, google.protobuf.UInt32Value> map_uint64_uint32_wrapper = 307;
+  map<uint64, google.protobuf.StringValue> map_uint64_string_wrapper = 308;
+  map<uint64, google.protobuf.BoolValue> map_uint64_bool_wrapper = 309;
+  map<uint64, google.protobuf.BytesValue> map_uint64_bytes_wrapper = 310;
+
+  map<string, bool> map_string_bool = 218;
+  map<string, string> map_string_string = 61;
+  map<string, bytes> map_string_bytes = 219;
+  map<string, int32> map_string_int32 = 220;
+  map<string, int64> map_string_int64 = 221;
+  map<string, uint32> map_string_uint32 = 222;
+  map<string, uint64> map_string_uint64 = 223;
+  map<string, float> map_string_float = 224;
+  map<string, double> map_string_double = 225;
+  map<string, NestedEnum> map_string_enum = 226;
+  map<string, NestedMessage> map_string_message = 227;
+  map<string, google.protobuf.Duration> map_string_duration = 243;
+  map<string, google.protobuf.Timestamp> map_string_timestamp = 244;
+  map<string, google.protobuf.NullValue> map_string_null_value = 245;
+  map<string, google.protobuf.Any> map_string_any = 311;
+  map<string, google.protobuf.Struct> map_string_struct = 312;
+  map<string, google.protobuf.Value> map_string_value = 313;
+  map<string, google.protobuf.ListValue> map_string_list_value = 314;
+  map<string, google.protobuf.Int64Value> map_string_int64_wrapper = 315;
+  map<string, google.protobuf.Int32Value> map_string_int32_wrapper = 316;
+  map<string, google.protobuf.DoubleValue> map_string_double_wrapper = 317;
+  map<string, google.protobuf.FloatValue> map_string_float_wrapper = 318;
+  map<string, google.protobuf.UInt64Value> map_string_uint64_wrapper = 319;
+  map<string, google.protobuf.UInt32Value> map_string_uint32_wrapper = 320;
+  map<string, google.protobuf.StringValue> map_string_string_wrapper = 321;
+  map<string, google.protobuf.BoolValue> map_string_bool_wrapper = 322;
+  map<string, google.protobuf.BytesValue> map_string_bytes_wrapper = 323;
+}
+
+// This proto includes a recursively nested message.
+message NestedTestAllTypes {
+  NestedTestAllTypes child = 1;
+  TestAllTypes payload = 2;
+}
+
+// This proto tests that global enums are resolved correctly.
+enum GlobalEnum {
+  GOO = 0;
+  GAR = 1;
+  GAZ = 2;
+}

--- a/proto/cel/expr/conformance/simple.proto
+++ b/proto/cel/expr/conformance/simple.proto
@@ -1,0 +1,127 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Simple end-to-end conformance tests.
+
+syntax = "proto3";
+
+package cel.expr.conformance;
+
+import "cel/expr/checked.proto";
+import "cel/expr/eval.proto";
+import "cel/expr/value.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr/conformance";
+option java_multiple_files = true;
+option java_outer_classname = "SimpleProto";
+option java_package = "dev.cel.expr.conformance";
+
+// The format of a simple test file, expected to be stored in text format.
+// A file is the unit of granularity for selecting conformance tests,
+// so tests of optional features should be segregated into separate files.
+message SimpleTestFile {
+  // Required.  The name of the file.  Should match the filename.
+  string name = 1;
+
+  // A description of the file.
+  string description = 2;
+
+  // The contained sections.
+  repeated SimpleTestSection section = 3;
+}
+
+// A collection of related SimpleTests.
+//
+// The section is the unit of organization within a test file, and should
+// guide where new tests are added.
+message SimpleTestSection {
+  // Required.  The name of the section.
+  string name = 1;
+
+  // A description of the section.
+  string description = 2;
+
+  // The contained tests.
+  repeated SimpleTest test = 3;
+}
+
+// A test which should run the given CEL program through parsing,
+// optionally through checking, then evaluation, with the results
+// of the pipeline validated by the given result matcher.
+message SimpleTest {
+  // Required.  The name of the test, which should be unique in the test file.
+  string name = 1;
+
+  // A description of the test.
+  string description = 2;
+
+  // Required.  The text of the CEL expression.
+  string expr = 3;
+
+  // Disables all macro expansion in parsing.
+  bool disable_macros = 4;
+
+  // Disables the check phase.
+  bool disable_check = 5;
+
+  // The type environment to use for the check phase.
+  repeated cel.expr.Decl type_env = 6;
+
+  // The container for name resolution.
+  string container = 13;
+
+  // The locale to use for the evaluation phase.
+  string locale = 14;
+
+  // Variable bindings to use for the eval phase.
+  map<string, cel.expr.ExprValue> bindings = 7;
+
+  // An unspecified result defaults to a matcher for the true boolean value.
+  oneof result_matcher {
+    // A normal value, which must match the evaluation result exactly
+    // via value equality semantics.  This coincides with proto equality,
+    // except for:
+    // *   maps are order-agnostic.
+    // *   a floating point NaN should match any NaN.
+    cel.expr.Value value = 8;
+
+    // Matches error evaluation results.
+    cel.expr.ErrorSet eval_error = 9;
+
+    // Matches one of several error results.
+    // (Using explicit message since oneof can't handle repeated.)
+    ErrorSetMatcher any_eval_errors = 10;
+
+    // Matches unknown evaluation results.
+    cel.expr.UnknownSet unknown = 11;
+
+    // Matches one of several unknown results.
+    // (Using explicit message since oneof can't handle repeated.)
+    UnknownSetMatcher any_unknowns = 12;
+  }
+  // Next is 15.
+}
+
+// Matches error results from Eval.
+message ErrorSetMatcher {
+  // Success if we match any of these sets.
+  repeated cel.expr.ErrorSet errors = 1;
+}
+
+// Matches unknown results from Eval.
+message UnknownSetMatcher {
+  // Success if we match any of these sets.
+  repeated cel.expr.UnknownSet unknowns = 1;
+}

--- a/proto/cel/expr/eval.proto
+++ b/proto/cel/expr/eval.proto
@@ -1,0 +1,116 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "cel/expr/value.proto";
+import "google/rpc/status.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "EvalProto";
+option java_package = "dev.cel.expr";
+
+// The state of an evaluation.
+//
+// Can represent an initial, partial, or completed state of evaluation.
+message EvalState {
+  // A single evaluation result.
+  message Result {
+    // The id of the expression this result if for.
+    int64 expr = 1;
+
+    // The index in `values` of the resulting value.
+    int64 value = 2;
+  }
+
+  // The unique values referenced in this message.
+  repeated ExprValue values = 1;
+
+  // An ordered list of results.
+  //
+  // Tracks the flow of evaluation through the expression.
+  // May be sparse.
+  repeated Result results = 3;
+}
+
+// The value of an evaluated expression.
+message ExprValue {
+  // An expression can resolve to a value, error or unknown.
+  oneof kind {
+    Value value = 1;
+
+    // The set of errors in the critical path of evaluation.
+    //
+    // Only errors in the critical path are included. For example,
+    // `(<error1> || true) && <error2>` will only result in `<error2>`,
+    // while `<error1> || <error2>` will result in both `<error1>` and
+    // `<error2>`.
+    //
+    // Errors cause by the presence of other errors are not included in the
+    // set. For example `<error1>.foo`, `foo(<error1>)`, and `<error1> + 1` will
+    // only result in `<error1>`.
+    //
+    // Multiple errors *might* be included when evaluation could result
+    // in different errors. For example `<error1> + <error2>` and
+    // `foo(<error1>, <error2>)` may result in `<error1>`, `<error2>` or both.
+    // The exact subset of errors included for this case is unspecified and
+    // depends on the implementation details of the evaluator.
+    ErrorSet error = 2;
+
+    // The set of unknowns in the critical path of evaluation.
+    //
+    // Unknown behaves identically to Error with regards to propagation.
+    // Specifically, only unknowns in the critical path are included, unknowns
+    // caused by the presence of other unknowns are not included, and multiple
+    // unknowns *might* be included when evaluation could result in
+    // different unknowns. For example:
+    //
+    //     (<unknown[1]> || true) && <unknown[2]> -> <unknown[2]>
+    //     <unknown[1]> || <unknown[2]> -> <unknown[1,2]>
+    //     <unknown[1]>.foo -> <unknown[1]>
+    //     foo(<unknown[1]>) -> <unknown[1]>
+    //     <unknown[1]> + <unknown[2]> -> <unknown[1]> or <unknown[2[>
+    //
+    // Unknown takes precedence over Error in cases where a `Value` can short
+    // circuit the result:
+    //
+    //     <error> || <unknown> -> <unknown>
+    //     <error> && <unknown> -> <unknown>
+    //
+    // Errors take precedence in all other cases:
+    //
+    //     <unknown> + <error> -> <error>
+    //     foo(<unknown>, <error>) -> <error>
+    UnknownSet unknown = 3;
+  }
+}
+
+// A set of errors.
+//
+// The errors included depend on the context. See `ExprValue.error`.
+message ErrorSet {
+  repeated google.rpc.Status errors = 1;
+}
+
+// A set of expressions for which the value is unknown.
+//
+// The unknowns included depend on the context. See `ExprValue.unknown`.
+message UnknownSet {
+  // The ids of the expressions with unknown values.
+  repeated int64 exprs = 1;
+}

--- a/proto/cel/expr/explain.proto
+++ b/proto/cel/expr/explain.proto
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "cel/expr/value.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "ExplainProto";
+option java_package = "dev.cel.expr";
+
+// Values of intermediate expressions produced when evaluating expression.
+message Explain {
+  option deprecated = true;
+
+  // ID and value index of one step.
+  message ExprStep {
+    // ID of corresponding Expr node.
+    int64 id = 1;
+
+    // Index of the value in the values list.
+    int32 value_index = 2;
+  }
+
+  // All of the observed values.
+  //
+  // The field value_index is an index in the values list.
+  // Separating values from steps is needed to remove redundant values.
+  repeated Value values = 1;
+
+  // List of steps.
+  //
+  // Repeated evaluations of the same expression generate new ExprStep
+  // instances. The order of such ExprStep instances matches the order of
+  // elements returned by Comprehension.iter_range.
+  repeated ExprStep expr_steps = 2;
+}

--- a/proto/cel/expr/syntax.proto
+++ b/proto/cel/expr/syntax.proto
@@ -1,0 +1,344 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "SyntaxProto";
+option java_package = "dev.cel.expr";
+
+// A representation of the abstract syntax of the Common Expression Language.
+
+// An expression together with source information as returned by the parser.
+message ParsedExpr {
+  // The parsed expression.
+  Expr expr = 2;
+
+  // The source info derived from input that generated the parsed `expr`.
+  SourceInfo source_info = 3;
+}
+
+// An abstract representation of a common expression.
+//
+// Expressions are abstractly represented as a collection of identifiers,
+// select statements, function calls, literals, and comprehensions. All
+// operators with the exception of the '.' operator are modelled as function
+// calls. This makes it easy to represent new operators into the existing AST.
+//
+// All references within expressions must resolve to a
+// [Decl][cel.expr.Decl] provided at type-check for an expression to be
+// valid. A reference may either be a bare identifier `name` or a qualified
+// identifier `google.api.name`. References may either refer to a value or a
+// function declaration.
+//
+// For example, the expression `google.api.name.startsWith('expr')` references
+// the declaration `google.api.name` within a
+// [Expr.Select][cel.expr.Expr.Select] expression, and the function
+// declaration `startsWith`.
+message Expr {
+  // An identifier expression. e.g. `request`.
+  message Ident {
+    // Required. Holds a single, unqualified identifier, possibly preceded by a
+    // '.'.
+    //
+    // Qualified names are represented by the
+    // [Expr.Select][cel.expr.Expr.Select] expression.
+    string name = 1;
+  }
+
+  // A field selection expression. e.g. `request.auth`.
+  message Select {
+    // Required. The target of the selection expression.
+    //
+    // For example, in the select expression `request.auth`, the `request`
+    // portion of the expression is the `operand`.
+    Expr operand = 1;
+
+    // Required. The name of the field to select.
+    //
+    // For example, in the select expression `request.auth`, the `auth` portion
+    // of the expression would be the `field`.
+    string field = 2;
+
+    // Whether the select is to be interpreted as a field presence test.
+    //
+    // This results from the macro `has(request.auth)`.
+    bool test_only = 3;
+  }
+
+  // A call expression, including calls to predefined functions and operators.
+  //
+  // For example, `value == 10`, `size(map_value)`.
+  message Call {
+    // The target of an method call-style expression. For example, `x` in
+    // `x.f()`.
+    Expr target = 1;
+
+    // Required. The name of the function or method being called.
+    string function = 2;
+
+    // The arguments.
+    repeated Expr args = 3;
+  }
+
+  // A list creation expression.
+  //
+  // Lists may either be homogenous, e.g. `[1, 2, 3]`, or heterogeneous, e.g.
+  // `dyn([1, 'hello', 2.0])`
+  message CreateList {
+    // The elements part of the list.
+    repeated Expr elements = 1;
+
+    // The indices within the elements list which are marked as optional
+    // elements.
+    //
+    // When an optional-typed value is present, the value it contains
+    // is included in the list. If the optional-typed value is absent, the list
+    // element is omitted from the CreateList result.
+    repeated int32 optional_indices = 2;
+  }
+
+  // A map or message creation expression.
+  //
+  // Maps are constructed as `{'key_name': 'value'}`. Message construction is
+  // similar, but prefixed with a type name and composed of field ids:
+  // `types.MyType{field_id: 'value'}`.
+  message CreateStruct {
+    // Represents an entry.
+    message Entry {
+      // Required. An id assigned to this node by the parser which is unique
+      // in a given expression tree. This is used to associate type
+      // information and other attributes to the node.
+      int64 id = 1;
+
+      // The `Entry` key kinds.
+      oneof key_kind {
+        // The field key for a message creator statement.
+        string field_key = 2;
+
+        // The key expression for a map creation statement.
+        Expr map_key = 3;
+      }
+
+      // Required. The value assigned to the key.
+      //
+      // If the optional_entry field is true, the expression must resolve to an
+      // optional-typed value. If the optional value is present, the key will be
+      // set; however, if the optional value is absent, the key will be unset.
+      Expr value = 4;
+
+      // Whether the key-value pair is optional.
+      bool optional_entry = 5;
+    }
+
+    // The type name of the message to be created, empty when creating map
+    // literals.
+    string message_name = 1;
+
+    // The entries in the creation expression.
+    repeated Entry entries = 2;
+  }
+
+  // A comprehension expression applied to a list or map.
+  //
+  // Comprehensions are not part of the core syntax, but enabled with macros.
+  // A macro matches a specific call signature within a parsed AST and replaces
+  // the call with an alternate AST block. Macro expansion happens at parse
+  // time.
+  //
+  // The following macros are supported within CEL:
+  //
+  // Aggregate type macros may be applied to all elements in a list or all keys
+  // in a map:
+  //
+  // *  `all`, `exists`, `exists_one` -  test a predicate expression against
+  //    the inputs and return `true` if the predicate is satisfied for all,
+  //    any, or only one value `list.all(x, x < 10)`.
+  // *  `filter` - test a predicate expression against the inputs and return
+  //    the subset of elements which satisfy the predicate:
+  //    `payments.filter(p, p > 1000)`.
+  // *  `map` - apply an expression to all elements in the input and return the
+  //    output aggregate type: `[1, 2, 3].map(i, i * i)`.
+  //
+  // The `has(m.x)` macro tests whether the property `x` is present in struct
+  // `m`. The semantics of this macro depend on the type of `m`. For proto2
+  // messages `has(m.x)` is defined as 'defined, but not set`. For proto3, the
+  // macro tests whether the property is set to its default. For map and struct
+  // types, the macro tests whether the property `x` is defined on `m`.
+  //
+  // Comprehension evaluation can be best visualized as the following
+  // pseudocode:
+  //
+  // ```
+  // let `accu_var` = `accu_init`
+  // for (let `iter_var` in `iter_range`) {
+  //   if (!`loop_condition`) {
+  //     break
+  //   }
+  //   `accu_var` = `loop_step`
+  // }
+  // return `result`
+  // ```
+  message Comprehension {
+    // The name of the iteration variable.
+    string iter_var = 1;
+
+    // The range over which var iterates.
+    Expr iter_range = 2;
+
+    // The name of the variable used for accumulation of the result.
+    string accu_var = 3;
+
+    // The initial value of the accumulator.
+    Expr accu_init = 4;
+
+    // An expression which can contain iter_var and accu_var.
+    //
+    // Returns false when the result has been computed and may be used as
+    // a hint to short-circuit the remainder of the comprehension.
+    Expr loop_condition = 5;
+
+    // An expression which can contain iter_var and accu_var.
+    //
+    // Computes the next value of accu_var.
+    Expr loop_step = 6;
+
+    // An expression which can contain accu_var.
+    //
+    // Computes the result.
+    Expr result = 7;
+  }
+
+  // Required. An id assigned to this node by the parser which is unique in a
+  // given expression tree. This is used to associate type information and other
+  // attributes to a node in the parse tree.
+  int64 id = 2;
+
+  // Required. Variants of expressions.
+  oneof expr_kind {
+    // A constant expression.
+    Constant const_expr = 3;
+
+    // An identifier expression.
+    Ident ident_expr = 4;
+
+    // A field selection expression, e.g. `request.auth`.
+    Select select_expr = 5;
+
+    // A call expression, including calls to predefined functions and operators.
+    Call call_expr = 6;
+
+    // A list creation expression.
+    CreateList list_expr = 7;
+
+    // A map or message creation expression.
+    CreateStruct struct_expr = 8;
+
+    // A comprehension expression.
+    Comprehension comprehension_expr = 9;
+  }
+}
+
+// Represents a primitive literal.
+//
+// Named 'Constant' here for backwards compatibility.
+//
+// This is similar as the primitives supported in the well-known type
+// `google.protobuf.Value`, but richer so it can represent CEL's full range of
+// primitives.
+//
+// Lists and structs are not included as constants as these aggregate types may
+// contain [Expr][cel.expr.Expr] elements which require evaluation and
+// are thus not constant.
+//
+// Examples of constants include: `"hello"`, `b'bytes'`, `1u`, `4.2`, `-2`,
+// `true`, `null`.
+message Constant {
+  // Required. The valid constant kinds.
+  oneof constant_kind {
+    // null value.
+    google.protobuf.NullValue null_value = 1;
+
+    // boolean value.
+    bool bool_value = 2;
+
+    // int64 value.
+    int64 int64_value = 3;
+
+    // uint64 value.
+    uint64 uint64_value = 4;
+
+    // double value.
+    double double_value = 5;
+
+    // string value.
+    string string_value = 6;
+
+    // bytes value.
+    bytes bytes_value = 7;
+
+    // protobuf.Duration value.
+    //
+    // Deprecated: duration is no longer considered a builtin cel type.
+    google.protobuf.Duration duration_value = 8 [deprecated = true];
+
+    // protobuf.Timestamp value.
+    //
+    // Deprecated: timestamp is no longer considered a builtin cel type.
+    google.protobuf.Timestamp timestamp_value = 9 [deprecated = true];
+  }
+}
+
+// Source information collected at parse time.
+message SourceInfo {
+  // The syntax version of the source, e.g. `cel1`.
+  string syntax_version = 1;
+
+  // The location name. All position information attached to an expression is
+  // relative to this location.
+  //
+  // The location could be a file, UI element, or similar. For example,
+  // `acme/app/AnvilPolicy.cel`.
+  string location = 2;
+
+  // Monotonically increasing list of code point offsets where newlines
+  // `\n` appear.
+  //
+  // The line number of a given position is the index `i` where for a given
+  // `id` the `line_offsets[i] < id_positions[id] < line_offsets[i+1]`. The
+  // column may be derived from `id_positions[id] - line_offsets[i]`.
+  repeated int32 line_offsets = 3;
+
+  // A map from the parse node id (e.g. `Expr.id`) to the code point offset
+  // within the source.
+  map<int64, int32> positions = 4;
+
+  // A map from the parse node id where a macro replacement was made to the
+  // call `Expr` that resulted in a macro expansion.
+  //
+  // For example, `has(value.field)` is a function call that is replaced by a
+  // `test_only` field selection in the AST. Likewise, the call
+  // `list.exists(e, e > 10)` translates to a comprehension expression. The key
+  // in the map corresponds to the expression id of the expanded macro, and the
+  // value is the call `Expr` that was replaced.
+  map<int64, Expr> macro_calls = 5;
+}

--- a/proto/cel/expr/value.proto
+++ b/proto/cel/expr/value.proto
@@ -1,0 +1,114 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "ValueProto";
+option java_package = "dev.cel.expr";
+
+// Contains representations for CEL runtime values.
+
+// Represents a CEL value.
+//
+// This is similar to `google.protobuf.Value`, but can represent CEL's full
+// range of values.
+message Value {
+  // Required. The valid kinds of values.
+  oneof kind {
+    // Null value.
+    google.protobuf.NullValue null_value = 1;
+
+    // Boolean value.
+    bool bool_value = 2;
+
+    // Signed integer value.
+    int64 int64_value = 3;
+
+    // Unsigned integer value.
+    uint64 uint64_value = 4;
+
+    // Floating point value.
+    double double_value = 5;
+
+    // UTF-8 string value.
+    string string_value = 6;
+
+    // Byte string value.
+    bytes bytes_value = 7;
+
+    // An enum value.
+    EnumValue enum_value = 9;
+
+    // The proto message backing an object value.
+    google.protobuf.Any object_value = 10;
+
+    // Map value.
+    MapValue map_value = 11;
+
+    // List value.
+    ListValue list_value = 12;
+
+    // Type value.
+    string type_value = 15;
+  }
+}
+
+// An enum value.
+message EnumValue {
+  // The fully qualified name of the enum type.
+  string type = 1;
+
+  // The value of the enum.
+  int32 value = 2;
+}
+
+// A list.
+//
+// Wrapped in a message so 'not set' and empty can be differentiated, which is
+// required for use in a 'oneof'.
+message ListValue {
+  // The ordered values in the list.
+  repeated Value values = 1;
+}
+
+// A map.
+//
+// Wrapped in a message so 'not set' and empty can be differentiated, which is
+// required for use in a 'oneof'.
+message MapValue {
+  message Entry {
+    // The key.
+    //
+    // Must be unique with in the map.
+    // Currently only boolean, int, uint, and string values can be keys.
+    Value key = 1;
+
+    // The value.
+    Value value = 2;
+  }
+
+  // The set of map entries.
+  //
+  // CEL has fewer restrictions on keys, so a protobuf map representation
+  // cannot be used.
+  repeated Entry entries = 1;
+}


### PR DESCRIPTION
To match the following:
- proto: cel.expr.* / "cel/expr/*"
- c++: cel::expr::* / "cel/expr/*"
- go: cel.dev/expr
- java: dev.cel.expr (unchanged)

The tld is typically not included in proto/c++, and was in the wrong spot for the go package.

This leaves the existing protos inplace, to allow for a transition to the new packages.