### PR TITLE
Update TestGrid link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ For more detail, see:
 *   [Introduction](doc/intro.md)
 *   [Language Definition](doc/langdef.md)
 
-A dashboard that shows results of conformance tests on current CEL
-implementations can be found
-[here](https://k8s-testgrid.appspot.com/google-cel).
-
 Released under the [Apache License](LICENSE).
 
 Disclaimer: This is not an official Google product.


### PR DESCRIPTION
The test grid link in the README.md refers to a dashboard
which hasn't been updated since 2020. 

Conformance can better be determined from running the conformance
test target in the [cel-go](https://github.com/google/cel-go),  [cel-cpp](https://github.com/google/cel-cpp), or [cel-java](https://github.com/google/cel-java) repos directly.

Closes #309 