### PR TITLE
Add support for a ping command to pipe clients.

### DIFF
--- a/tests/simple/simple_test.go
+++ b/tests/simple/simple_test.go
@@ -49,6 +49,7 @@ var (
 	flagSkipCheck      bool
 	flagSkipTests      stringArray
 	flagPipe           bool
+	flagPipePings      bool
 	flagPipeBase64     bool
 	rc                 *runConfig
 )
@@ -62,7 +63,8 @@ func init() {
 	flag.BoolVar(&flagSkipCheck, "skip_check", false, "force skipping the check phase")
 	flag.Var(&flagSkipTests, "skip_test", "name(s) of tests to skip. can be set multiple times. to skip the following tests: f1/s1/t1, f1/s1/t2, f1/s2/*, f2/s3/t3, you give the arguments --skip_test=f1/s1/t1,t2;s2 --skip_test=f2/s3/t3")
 	flag.BoolVar(&flagPipe, "pipe", false, "Use pipes instead of gRPC")
-	flag.BoolVar(&flagPipeBase64, "pipe_base64", false, "Use base64 encoded wire format proto in pipes (default JSON).")
+	flag.BoolVar(&flagPipeBase64, "pipe_base64", true, "Use base64 encoded wire format proto in pipes (if disabled, use JSON).")
+	flag.BoolVar(&flagPipePings, "pipe_pings", false, "Enable pinging pipe client to subprocess status.")
 
 	flag.Parse()
 }
@@ -103,7 +105,7 @@ func initRunConfig() (*runConfig, error) {
 		var cli celrpc.ConfClient
 		var err error
 		if flagPipe {
-			cli, err = celrpc.NewPipeClient(cmd, flagPipeBase64)
+			cli, err = celrpc.NewPipeClient(cmd, flagPipeBase64, flagPipePings)
 		} else {
 			cli, err = celrpc.NewGrpcClient(cmd)
 		}

--- a/tools/celrpc/BUILD.bazel
+++ b/tools/celrpc/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@org_golang_google_grpc//reflection:go_default_library",
         "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
     ],
 )
 

--- a/tools/celrpc/testpipeimpl/main/BUILD.bazel
+++ b/tools/celrpc/testpipeimpl/main/BUILD.bazel
@@ -12,6 +12,7 @@ go_binary(
     deps = [
         "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
         "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
         "@org_golang_google_genproto_googleapis_api//expr/conformance/v1alpha1:go_default_library",
         "@org_golang_google_genproto_googleapis_rpc//status:go_default_library", 

--- a/tools/celrpc/testpipeimpl/main/main.go
+++ b/tools/celrpc/testpipeimpl/main/main.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	confpb "google.golang.org/genproto/googleapis/api/expr/conformance/v1alpha1"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -138,6 +139,10 @@ func processLoop() int {
 				}
 			}
 
+			if req.CelSource == "test_crash" {
+				os.Exit(2)
+			}
+
 			if err = c.serialize(writer, &resp); err != nil {
 				fmt.Fprintf(os.Stderr, "error serializing parse resp %v\n", err)
 				return 1
@@ -180,6 +185,17 @@ func processLoop() int {
 			}
 			if err = c.serialize(writer, &resp); err != nil {
 				fmt.Fprintf(os.Stderr, "error serializing check resp %v\n", err)
+				return 1
+			}
+		case "ping":
+			req := emptypb.Empty{}
+			if err := c.unmarshal(msg, &req); err != nil {
+				fmt.Fprintf(os.Stderr, "bad ping req: %v\n", err)
+				return 1
+			}
+			resp := emptypb.Empty{}
+			if err = c.serialize(writer, &resp); err != nil {
+				fmt.Fprintf(os.Stderr, "error serializing ping resp %v\n", err)
 				return 1
 			}
 		default:


### PR DESCRIPTION
- Add  a simple ping protocol to pipe clients conformance service
- Pinging the subprocess tends to be a bit more reliable than checking health via other means
- Default pipe to use base64 encoding instead of JSON