### PR TITLE
Add py_proto_library support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,10 +20,10 @@ http_archive(
 
 http_archive(
     name = "rules_proto",
-    sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
-    strip_prefix = "rules_proto-4.0.0-3.20.0",
+    sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+    strip_prefix = "rules_proto-5.3.0-21.7",
     urls = [
-        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
     ],
 )
 
@@ -81,10 +81,19 @@ http_archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
 )
 
+# rules-python
+http_archive(
+    name = "rules_python",
+    sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
+    strip_prefix = "rules_python-0.26.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
+)
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_python//python:repositories.bzl", "py_repositories")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 switched_rules_by_language(
@@ -140,6 +149,7 @@ go_repository(
 go_rules_dependencies()
 go_register_toolchains(version = "1.19.1")
 gazelle_dependencies()
+py_repositories()
 rules_proto_dependencies()
 rules_proto_toolchains()
 protobuf_deps()

--- a/proto/cel/expr/BUILD.bazel
+++ b/proto/cel/expr/BUILD.bazel
@@ -206,3 +206,38 @@ cc_proto_library(
     name = "explain_cc_proto",
     deps = [":explain_proto"],
 )
+
+###############################################################################
+## Python
+###############################################################################
+load("@rules_python//python:proto.bzl", "py_proto_library")
+
+py_proto_library(
+    name = "expr_py_pb2",
+    deps = [":expr_proto"],
+)
+
+py_proto_library(
+    name = "syntax_py_pb2",
+    deps = [":syntax_proto"],
+)
+
+py_proto_library(
+    name = "checked_py_pb2",
+    deps = [":checked_proto"],
+)
+
+py_proto_library(
+    name = "value_py_pb2",
+    deps = [":value_proto"],
+)
+
+py_proto_library(
+    name = "eval_py_pb2",
+    deps = [":eval_proto"],
+)
+
+py_proto_library(
+    name = "explain_py_pb2",
+    deps = [":explain_proto"],
+)


### PR DESCRIPTION
Needed to add the support of the new stable CEL to [cncf/xds](https://github.com/cncf/xds/blob/main/xds/type/v3/cel.proto).