### PR TITLE
[docs] Update langdef.md to include 3-arg map fn

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -704,12 +704,14 @@ macros are:
     if the predicate of exactly one element/key evaluates to `true`, and the
     rest to `false`. Any other combination of boolean results evaluates to
     `false`, and any predicate error causes the macro to raise an error.
-*   `e.map(x, t)` transforms a list `e` by taking each element `x` to the
+*   `e.map(x, t)`: transforms a list `e` by taking each element `x` to the
     function given by the expression `t`, which can use the variable `x`. For
     instance, `[1, 2, 3].map(n, n * n)` evaluates to `[1, 4, 9]`. Any evaluation
     error for any element causes the macro to raise an error. The `map()` macro
     is not supported when `e` is a map.
-*   `e.filter(x, p)` returns the sublist of all elements `x` of list `e` which
+*   `e.map(x, p, t)`: Same as the two-arg map but with a conditional `p` filter
+    before the value is transformed.
+*   `e.filter(x, p)`: returns the sublist of all elements `x` of list `e` which
     evaluate to `true` in the predicate expression `p` (which can use variable
     `x`). For instance, `[1, 2, 3].filter(i, i % 2 > 0)` evaluates to `[1, 3]`.
     If no elements evaluate to `true`, the result is an empty list. Any


### PR DESCRIPTION
The specification is missing the 3 arg map function, which allows for condition, `p`, which is evaluated before the transformation. Updating the language spec docs to include this existing function.

\- adamsinclair@