### PR TITLE
doc/langdef: update documentation for .map() and .filter()

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -704,19 +704,28 @@ macros are:
     if the predicate of exactly one element/key evaluates to `true`, and the
     rest to `false`. Any other combination of boolean results evaluates to
     `false`, and any predicate error causes the macro to raise an error.
-*   `e.map(x, t)`: transforms a list `e` by taking each element `x` to the
-    function given by the expression `t`, which can use the variable `x`. For
-    instance, `[1, 2, 3].map(n, n * n)` evaluates to `[1, 4, 9]`. Any evaluation
-    error for any element causes the macro to raise an error. The `map()` macro
-    is not supported when `e` is a map.
+*   `e.map(x, t)`:
+  *    transforms a list `e` by taking each element `x` to the
+       function given by the expression `t`, which can use the variable `x`. For
+       instance, `[1, 2, 3].map(n, n * n)` evaluates to `[1, 4, 9]`. Any evaluation
+       error for any element causes the macro to raise an error.
+  *    transforms a map `e` by taking each key in the map `x` to the function 
+       given by the expression `t`, which can use the variable `x`. For
+       instance, `{'one': 1, 'two': 2}.map(k, k)` evaluates to `['one', 'two']`. 
+       Any evaluation error for any element causes the macro to raise an error.
 *   `e.map(x, p, t)`: Same as the two-arg map but with a conditional `p` filter
     before the value is transformed.
-*   `e.filter(x, p)`: returns the sublist of all elements `x` of list `e` which
-    evaluate to `true` in the predicate expression `p` (which can use variable
-    `x`). For instance, `[1, 2, 3].filter(i, i % 2 > 0)` evaluates to `[1, 3]`.
-    If no elements evaluate to `true`, the result is an empty list. Any
-    evaluation error for any element causes the macro to raise an error. The
-    `filter()` macro is not supported on maps.
+*   `e.filter(x, p)`: 
+  *    for a list `e`, returns the sublist of all elements `x` which
+       evaluate to `true` in the predicate expression `p` (which can use variable
+       `x`). For instance, `[1, 2, 3].filter(i, i % 2 > 0)` evaluates to `[1, 3]`.
+       If no elements evaluate to `true`, the result is an empty list. Any
+       evaluation error for any element causes the macro to raise an error.
+  *    for a map `e`, returns the list of all map keys `x` which
+       evaluate to `true` in the predicate expression `p` (which can use variable
+       `x`). For instance, `{'one': 1, 'two': 2}.filter(k, k == 'one')` evaluates
+       to `['one']`. If no elements evaluate to `true`, the result is an empty
+       list. Any evaluation error for any element causes the macro to raise an error.
 
 ### Field Selection
 

--- a/tests/simple/testdata/macros.textproto
+++ b/tests/simple/testdata/macros.textproto
@@ -203,7 +203,11 @@ section {
       errors: { message: "divide by zero" }
     }
   }
-  # The map() macro is currently not supported for maps.
+  test {
+    name: "map_extract_keys"
+    expr: "{'John': 'smart', 'Paul': 'cute', 'George': 'quiet', 'Ringo': 'funny'}.map(key, key) == ['John', 'Paul', 'George', 'Ringo']"
+    value: { bool_value: true }
+  }
 }
 section {
   name: "filter"
@@ -257,7 +261,11 @@ section {
       errors: { message: "divide by zero" }
     }
   }
-  # The filter() macro is currently not supported for maps.
+  test {
+    name: "map_filter_keys"
+    expr: "{'John': 'smart', 'Paul': 'cute', 'George': 'quiet', 'Ringo': 'funny'}.filter(key, key == 'Ringo') == ['Ringo']"
+    value: { bool_value: true }
+  }
 }
 section {
   name: "nested"


### PR DESCRIPTION
These macros are documented as explicitly not applying to map values, but it seems like this documentation is out-of-date.

Expressions in the playground:
 - [`.map()`](https://playcel.undistro.io/?content=H4sIAAAAAAAAA6tWSkksSVSyUiouKcrMS%2FdNLLCKyVNQSLRSqADRSVYKlTF5MXlKOkqpFQVFqcXFmfl5yKr1chMLNLJ1FLI1lWoBx1LL3EwAAAA%3D)
 - [`.filter()`](https://playcel.undistro.io/?content=H4sIAAAAAAAAA6tWSkksSVSyUiouKcrMS%2FdNLLCKyVNQSLRSqADRSVYKlTF5MXlKOkqpFQVFqcXFmfl5yKr10jJzSlKLNLJ1FLIVbG0V1BPVNZVqAbO9entWAAAA)