### PR TITLE
Additional conformance tests for accessing a null valued field

### DIFF
--- a/tests/simple/testdata/optionals.textproto
+++ b/tests/simple/testdata/optionals.textproto
@@ -23,6 +23,18 @@ section: {
     value: { bool_value: false }
   }
   test {
+    name: "map_null_entry_no_such_key"
+    expr: "{'null_key': null}.?null_key.invalid.hasValue()"
+    eval_error: {
+      errors: { message: "no such key" }
+    }
+  }
+  test {
+    name: "map_undefined_entry_hasValue"
+    expr: "{}.?null_key.invalid.hasValue()"
+    value: { bool_value: false }
+  }
+  test {
     name: "map_submap_subkey_optFlatMap_value"
     expr: "{'key': {'subkey': 'subvalue'}}.?key.optFlatMap(k, k.?subkey).value()"
     value: { string_value: "subvalue" }


### PR DESCRIPTION
Ensure that accessing a null valued key is covered within optional tests

Within cel-go there was a bug where the implementation did not match the spec:
https://github.com/google/cel-go/issues/937