### PR TITLE
Conformance tests for 'null' assignment to a field

### DIFF
--- a/tests/simple/testdata/optionals.textproto
+++ b/tests/simple/testdata/optionals.textproto
@@ -3,6 +3,16 @@ description: "Tests for optionals."
 section: {
   name: "optionals"
   test {
+    name: "null"
+    expr: "optional.of(null).hasValue()"
+    value: { bool_value: true }
+  }
+  test {
+    name: "null_non_zero_value"
+    expr: "optional.ofNonZeroValue(null).hasValue()"
+    value: { bool_value: false }
+  }
+  test {
     name: "none_or_none_or_value"
     expr: "optional.none().or(optional.none()).orValue(42)"
     value: { int64_value: 42 }

--- a/tests/simple/testdata/proto2.textproto
+++ b/tests/simple/testdata/proto2.textproto
@@ -764,3 +764,81 @@ section {
     value { bool_value: true }
   }
 }
+section {
+  name:"set_null"
+  test {
+    name: "single_message"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_nested_message: null} == TestAllTypes{}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "single_any"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_any: null}.single_any"
+    value { null_value: NULL_VALUE }
+  }
+  test {
+    name: "single_value"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_value: null}.single_value"
+    value { null_value: NULL_VALUE }
+  }
+  test {
+    name: "single_duration"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_duration: null} == TestAllTypes{}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "single_timestamp"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_timestamp: null} == TestAllTypes{}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "single_scalar"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_bool: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+  test {
+    name: "repeated"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{repeated_int32: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+  test {
+    name: "map"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{map_string_string: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+  test {
+    name: "list_value"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{list_value: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+  test {
+    name: "single_struct"
+    container: "google.api.expr.test.v1.proto2"
+    expr: "TestAllTypes{single_struct: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+}

--- a/tests/simple/testdata/proto3.textproto
+++ b/tests/simple/testdata/proto3.textproto
@@ -666,3 +666,81 @@ section {
     value { bool_value: true }
   }
 }
+section {
+  name:"set_null"
+  test {
+    name: "single_message"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_nested_message: null} == TestAllTypes{}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "single_any"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_any: null}.single_any"
+    value { null_value: NULL_VALUE }
+  }
+  test {
+    name: "single_value"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_value: null}.single_value"
+    value { null_value: NULL_VALUE }
+  }
+  test {
+    name: "single_duration"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_duration: null} == TestAllTypes{}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "single_timestamp"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_timestamp: null} == TestAllTypes{}"
+    value: { bool_value: true }
+  }
+  test {
+    name: "single_scalar"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_bool: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+  test {
+    name: "repeated"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{repeated_int32: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+  test {
+    name: "map"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{map_string_string: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }  
+  test {
+    name: "list_value"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{list_value: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+  test {
+    name: "single_struct"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_struct: null} == TestAllTypes{}"
+    disable_check: true
+    eval_error: {
+      errors: { message: "unsupported field type" }
+    }
+  }
+}

--- a/tests/simple/testdata/wrappers.textproto
+++ b/tests/simple/testdata/wrappers.textproto
@@ -20,6 +20,14 @@ section {
       bool_value: true
     }
   }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_bool_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
+    }
+  }
 }
 
 # google.protobuf.Int32Value
@@ -39,6 +47,14 @@ section {
     expr: "TestAllTypes{single_value: google.protobuf.Int32Value{value: 1}}.single_value"
     value {
       double_value: 1
+    }
+  }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_int32_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
     }
   }
 }
@@ -70,6 +86,14 @@ section {
       string_value: "9223372036854775807"
     }
   }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_int64_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
+    }
+  }
 }
 
 # google.protobuf.UInt32Value
@@ -89,6 +113,14 @@ section {
     expr: "TestAllTypes{single_value: google.protobuf.UInt32Value{value: 1u}}.single_value"
     value {
       double_value: 1
+    }
+  }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_uint32_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
     }
   }
 }
@@ -120,6 +152,14 @@ section {
       string_value: "18446744073709551615"
     }
   }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_uint64_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
+    }
+  }
 }
 
 # google.protobuf.FloatValue
@@ -139,6 +179,14 @@ section {
     expr: "TestAllTypes{single_value: google.protobuf.FloatValue{value: 1.0}}.single_value"
     value {
       double_value: 1
+    }
+  }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_float_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
     }
   }
 }
@@ -162,6 +210,14 @@ section {
       double_value: 1
     }
   }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_double_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
+    }
+  }
 }
 
 # google.protobuf.BytesValue
@@ -183,6 +239,14 @@ section {
       string_value: "Zm9v"
     }
   }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_bytes_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
+    }
+  }
 }
 
 # google.protobuf.StringValue
@@ -202,6 +266,14 @@ section {
     expr: "TestAllTypes{single_value: google.protobuf.StringValue{value: 'foo'}}.single_value"
     value {
       string_value: "foo"
+    }
+  }
+  test {
+    name: "to_null"
+    container: "google.api.expr.test.v1.proto3"
+    expr: "TestAllTypes{single_string_wrapper: null} == TestAllTypes{}"
+    value {
+      bool_value: true
     }
   }
 }


### PR DESCRIPTION
Conformance tests for 'null' assignment to a field

Generally, setting a proto field to null within a `CreateStruct` block
should result in the field being unset; however, there are some exceptions:

* Repeated and map fields cannot be unset via `null`
* The `google.protobuf.Any` and `google.protobuf.Value` types 
   treat `null` as a concrete JSON `null`