### PR TITLE
Introduce iter_var2 in support of comprehensions v2

### DIFF
--- a/proto/cel/expr/syntax.proto
+++ b/proto/cel/expr/syntax.proto
@@ -199,10 +199,18 @@ message Expr {
   // return `result`
   // ```
   message Comprehension {
-    // The name of the iteration variable.
+    // The name of the first iteration variable.
+    // When the iter_range is a list, this variable is the list element.
+    // When the iter_range is a map, this variable is the map entry key.
     string iter_var = 1;
 
-    // The range over which var iterates.
+    // The name of the second iteration variable, empty if not set.
+    // When the iter_range is a list, this variable is the integer index.
+    // When the iter_range is a map, this variable is the map entry value.
+    // This field is only set for comprehension v2 macros.
+    string iter_var2 = 8;
+
+    // The range over which the comprehension iterates.
     Expr iter_range = 2;
 
     // The name of the variable used for accumulation of the result.
@@ -211,13 +219,13 @@ message Expr {
     // The initial value of the accumulator.
     Expr accu_init = 4;
 
-    // An expression which can contain iter_var and accu_var.
+    // An expression which can contain iter_var, iter_var2, and accu_var.
     //
     // Returns false when the result has been computed and may be used as
     // a hint to short-circuit the remainder of the comprehension.
     Expr loop_condition = 5;
 
-    // An expression which can contain iter_var and accu_var.
+    // An expression which can contain iter_var, iter_var2, and accu_var.
     //
     // Computes the next value of accu_var.
     Expr loop_step = 6;

--- a/proto/cel/expr/syntax.proto
+++ b/proto/cel/expr/syntax.proto
@@ -185,12 +185,28 @@ message Expr {
   // macro tests whether the property is set to its default. For map and struct
   // types, the macro tests whether the property `x` is defined on `m`.
   //
-  // Comprehension evaluation can be best visualized as the following
-  // pseudocode:
+  // Comprehensions for the standard environment macros evaluation can be best
+  // visualized as the following pseudocode:
   //
   // ```
   // let `accu_var` = `accu_init`
   // for (let `iter_var` in `iter_range`) {
+  //   if (!`loop_condition`) {
+  //     break
+  //   }
+  //   `accu_var` = `loop_step`
+  // }
+  // return `result`
+  // ```
+  //
+  // Comprehensions for the optional V2 macros which support map-to-map
+  // translation differ slightly from the standard environment macros in that
+  // they expose both the key or index in addition to the value for each list
+  // or map entry:
+  //
+  // ```
+  // let `accu_var` = `accu_init`
+  // for (let `iter_var`, `iter_var2` in `iter_range`) {
   //   if (!`loop_condition`) {
   //     break
   //   }


### PR DESCRIPTION
The comprehensions v2 support iteration over (key, value)
and (index, value) tuples within lists and maps.