### PR TITLE
Add nested groups to proto2 and optional fields to proto3 test protos

### DIFF
--- a/proto/test/v1/proto2/test_all_types.proto
+++ b/proto/test/v1/proto2/test_all_types.proto
@@ -297,6 +297,11 @@ message TestAllTypes {
     bool oneof_bool = 402;
   }
 
+  optional group NestedGroup = 403 {
+    optional int32 single_id = 404;
+    optional string single_name = 405;
+  }
+
   extensions 1000 to max;
 }
 

--- a/proto/test/v1/proto3/test_all_types.proto
+++ b/proto/test/v1/proto3/test_all_types.proto
@@ -48,6 +48,8 @@ message TestAllTypes {
   bool single_bool = 13;
   string single_string = 14;
   bytes single_bytes = 15;
+  optional bool optional_bool = 16;
+  optional bool optional_string = 17;
 
   // Wellknown.
   google.protobuf.Any single_any = 100;


### PR DESCRIPTION
This will allow the duplicate test_all_types proto to be removed from here: https://github.com/google/cel-java/blob/main/common/src/main/resources/testdata/proto2/test_all_types.proto