### PR TITLE
Remove local copy of google.rpc.Status proto

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
     importpath = "cel.dev/expr",
     visibility = ["//visibility:public"],
     deps = [
-        "//proto/cel/expr:google_rpc_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//runtime/protoimpl",
         "@org_golang_google_protobuf//types/known/anypb",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,13 +27,13 @@ http_archive(
     ],
 )
 
-# googleapis as of 05/26/2023
+# googleapis as of 09/16/2024
 http_archive(
     name = "com_google_googleapis",
-    strip_prefix = "googleapis-07c27163ac591955d736f3057b1619ece66f5b99",
-    sha256 = "bd8e735d881fb829751ecb1a77038dda4a8d274c45490cb9fcf004583ee10571",
+    strip_prefix = "googleapis-4082d5e51e8481f6ccc384cacd896f4e78f19dee",
+    sha256 = "57319889d47578b3c89bf1b3f34888d796a8913d63b32d750a4cd12ed303c4e8",
     urls = [
-        "https://github.com/googleapis/googleapis/archive/07c27163ac591955d736f3057b1619ece66f5b99.tar.gz",
+        "https://github.com/googleapis/googleapis/archive/4082d5e51e8481f6ccc384cacd896f4e78f19dee.tar.gz",
     ],
 )
 
@@ -95,22 +95,22 @@ switched_rules_by_language(
 # Do *not* call *_dependencies(), etc, yet.  See comment at the end.
 
 # Generated Google APIs protos for Golang
-# Generated Google APIs protos for Golang 05/25/2023
+# Generated Google APIs protos for Golang 08/26/2024
 go_repository(
     name = "org_golang_google_genproto_googleapis_api",
     build_file_proto_mode = "disable_global",
     importpath = "google.golang.org/genproto/googleapis/api",
-    sum = "h1:m8v1xLLLzMe1m5P+gCTF8nJB9epwZQUBERm20Oy1poQ=",
-    version = "v0.0.0-20230525234035-dd9d682886f9",
+    sum = "h1:YcyjlL1PRr2Q17/I0dPk2JmYS5CDXfcdb2Z3YRioEbw=",
+    version = "v0.0.0-20240826202546-f6391c0de4c7",
 )
 
-# Generated Google APIs protos for Golang 05/25/2023
+# Generated Google APIs protos for Golang 08/26/2024
 go_repository(
     name = "org_golang_google_genproto_googleapis_rpc",
     build_file_proto_mode = "disable_global",
     importpath = "google.golang.org/genproto/googleapis/rpc",
-    sum = "h1:0nDDozoAU19Qb2HwhXadU8OcsiO/09cnTqhUtq2MEOM=",
-    version = "v0.0.0-20230525234030-28d5490b6b19",
+    sum = "h1:2035KHhUv+EpyB+hWgJnaWKJOdX1E95w2S8Rr4uWKTs=",
+    version = "v0.0.0-20240826202546-f6391c0de4c7",
 )
 
 # gRPC deps

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module cel.dev/expr
 
-go 1.18
+go 1.21.1
+
+toolchain go1.23.0
 
 require (
 	github.com/bazelbuild/rules_go v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/bazelbuild/rules_go v0.49.0 h1:5vCbuvy8Q11g41lseGJDc5vxhDjJtfxr6nM/IC4VmqM=
 github.com/bazelbuild/rules_go v0.49.0/go.mod h1:Dhcz716Kqg1RHNWos+N6MlXNkjNP2EwZQ0LukRKJfMs=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=

--- a/proto/cel/expr/BUILD.bazel
+++ b/proto/cel/expr/BUILD.bazel
@@ -125,17 +125,11 @@ java_proto_library(
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 go_proto_library(
-    name = "google_rpc_status_go_proto",
-    importpath = "google.golang.org/genproto/googleapis/rpc/status",
-    protos = ["@com_google_googleapis//google/rpc:status_proto"],
-)
-
-go_proto_library(
     name = "expr_go_proto",
     importpath = "cel.dev/expr",
     protos = [":expr_proto"],
     deps = [
-        ":google_rpc_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status:go_default_library",
     ],
 )
 
@@ -164,7 +158,7 @@ go_proto_library(
     importpath = "cel.dev/expr",
     protos = [":eval_proto"],
     deps = [
-        ":google_rpc_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status:go_default_library",
     ],
 )
 

--- a/proto/cel/expr/conformance/BUILD.bazel
+++ b/proto/cel/expr/conformance/BUILD.bazel
@@ -85,7 +85,7 @@ go_proto_library(
     protos = [":conformance_proto"],
     deps = [
         "//proto/cel/expr:expr_go_proto",
-        "//proto/cel/expr:google_rpc_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status:go_default_library",
     ],
 )
 
@@ -95,7 +95,7 @@ go_proto_library(
     protos = [":conformance_service_proto"],
     deps = [
         "//proto/cel/expr:expr_go_proto",
-        "//proto/cel/expr:google_rpc_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status:go_default_library",
     ],
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,9 +1,9 @@
 module cel.dev/expr/tests
 
-go 1.18
+go 1.21.1
 
 require (
-	cel.dev/expr v0.16.0
+	cel.dev/expr v0.16.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7
 	google.golang.org/grpc v1.65.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,5 +1,7 @@
 github.com/bazelbuild/rules_go v0.49.0 h1:5vCbuvy8Q11g41lseGJDc5vxhDjJtfxr6nM/IC4VmqM=
+github.com/bazelbuild/rules_go v0.49.0/go.mod h1:Dhcz716Kqg1RHNWos+N6MlXNkjNP2EwZQ0LukRKJfMs=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=


### PR DESCRIPTION
The import path for a local google.rpc.Status rule may potentially be causing
problems for upstream users.

#390 