### PR TITLE
test, simple: Don't parse the flag in init()

### DIFF
--- a/tests/simple/simple_test.go
+++ b/tests/simple/simple_test.go
@@ -65,8 +65,6 @@ func init() {
 	flag.BoolVar(&flagPipe, "pipe", false, "Use pipes instead of gRPC")
 	flag.BoolVar(&flagPipeBase64, "pipe_base64", true, "Use base64 encoded wire format proto in pipes (if disabled, use JSON).")
 	flag.BoolVar(&flagPipePings, "pipe_pings", false, "Enable pinging pipe client to subprocess status.")
-
-	flag.Parse()
 }
 
 // Server binaries specified by flags


### PR DESCRIPTION
Doing the flag.Parse in init() erases the Go Test's builtin options such as -test.v. The right place to do that is TestMain and we even do that already. Remove the one in the init() function.

=== Before the change ===

Usage of ./simple.test:
  -check_server string
    	path to command for check server
  -checked_only
    	skip tests which skip type checking
  -eval_server string
    	path to command for eval server
  -parse_server string
    	path to command for parse server
  -pipe
    	Use pipes instead of gRPC
  -pipe_base64
    	Use base64 encoded wire format proto in pipes (if disabled, use JSON). (default true)
  -pipe_pings
    	Enable pinging pipe client to subprocess status.
  -server string
    	path to binary for server when no phase-specific server defined
  -skip_check
    	force skipping the check phase
  -skip_test value
    	name(s) of tests to skip. can be set multiple times. to skip the following tests: f1/s1/t1, f1/s1/t2, f1/s2/*, f2/s3/t3, you give the arguments --skip_test=f1/s1/t1,t2;s2 --skip_test=f2/s3/t3

=== After the change ===

Usage of ./simple.test:
  -check_server string
    	path to command for check server
  -checked_only
    	skip tests which skip type checking
  -eval_server string
    	path to command for eval server
  -parse_server string
    	path to command for parse server
  -pipe
    	Use pipes instead of gRPC
  -pipe_base64
    	Use base64 encoded wire format proto in pipes (if disabled, use JSON). (default true)
  -pipe_pings
    	Enable pinging pipe client to subprocess status.
  -server string
    	path to binary for server when no phase-specific server defined
  -skip_check
    	force skipping the check phase
  -skip_test value
    	name(s) of tests to skip. can be set multiple times. to skip the following tests: f1/s1/t1, f1/s1/t2, f1/s2/*, f2/s3/t3, you give the arguments --skip_test=f1/s1/t1,t2;s2 --skip_test=f2/s3/t3
  -test.bench regexp
    	run only benchmarks matching regexp
  -test.benchmem
    	print memory allocations for benchmarks
  -test.benchtime d
    	run each benchmark for duration d or N times if `d` is of the form Nx (default 1s)
  -test.blockprofile file
    	write a goroutine blocking profile to file
  -test.blockprofilerate rate
    	set blocking profile rate (see runtime.SetBlockProfileRate) (default 1)
  -test.count n
    	run tests and benchmarks n times (default 1)
  -test.coverprofile file
    	write a coverage profile to file
  -test.cpu list
    	comma-separated list of cpu counts to run each test with
  -test.cpuprofile file
    	write a cpu profile to file
  -test.failfast
    	do not start new tests after the first test failure
  -test.fullpath
    	show full file names in error messages
  -test.fuzz regexp
    	run the fuzz test matching regexp
  -test.fuzzcachedir string
    	directory where interesting fuzzing inputs are stored (for use only by cmd/go)
  -test.fuzzminimizetime value
    	time to spend minimizing a value after finding a failing input (default 1m0s)
  -test.fuzztime value
    	time to spend fuzzing; default is to run indefinitely
  -test.fuzzworker
    	coordinate with the parent process to fuzz random values (for use only by cmd/go)
  -test.gocoverdir string
    	write coverage intermediate files to this directory
  -test.list regexp
    	list tests, examples, and benchmarks matching regexp then exit
  -test.memprofile file
    	write an allocation profile to file
  -test.memprofilerate rate
    	set memory allocation profiling rate (see runtime.MemProfileRate)
  -test.mutexprofile string
    	write a mutex contention profile to the named file after execution
  -test.mutexprofilefraction int
    	if >= 0, calls runtime.SetMutexProfileFraction() (default 1)
  -test.outputdir dir
    	write profiles to dir
  -test.paniconexit0
    	panic on call to os.Exit(0)
  -test.parallel n
    	run at most n tests in parallel (default 4)
  -test.run regexp
    	run only tests and examples matching regexp
  -test.short
    	run smaller test suite to save time
  -test.shuffle string
    	randomize the execution order of tests and benchmarks (default "off")
  -test.skip regexp
    	do not list or run tests matching regexp
  -test.testlogfile file
    	write test action log to file (for use only by cmd/go)
  -test.timeout d
    	panic test binary after duration d (default 0, timeout disabled)
  -test.trace file
    	write an execution trace to file
  -test.v
    	verbose: print additional output