### PR TITLE
Temporarily restore simple.proto to its former location 

### DIFF
--- a/proto/test/v1/BUILD.bazel
+++ b/proto/test/v1/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+proto_library(
+    name = "simple_proto",
+    srcs = [
+        "simple.proto",
+    ],
+    deps = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:checked_proto",
+        "@com_google_googleapis//google/api/expr/v1alpha1:eval_proto",
+        "@com_google_googleapis//google/api/expr/v1alpha1:value_proto",
+        "@com_google_protobuf//:empty_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "simple_cc_proto",
+    deps = [":simple_proto",],
+)
+
+java_proto_library(
+    name = "simple_java_proto",
+    deps = [":simple_proto"],
+)

--- a/proto/test/v1/simple.proto
+++ b/proto/test/v1/simple.proto
@@ -1,0 +1,109 @@
+// Simple end-to-end conformance tests.
+
+syntax = "proto3";
+
+package google.api.expr.test.v1;
+
+// Note, run regen_go_proto.sh after making modifications to this file.
+option go_package = "cel.dev/expr/test/v1/testpb";
+option java_outer_classname = "SimpleProto";
+option java_package = "com.google.api.expr.test.v1";
+
+import "google/api/expr/v1alpha1/checked.proto";
+import "google/api/expr/v1alpha1/eval.proto";
+import "google/api/expr/v1alpha1/value.proto";
+
+// The format of a simple test file, expected to be stored in text format.
+// A file is the unit of granularity for selecting conformance tests,
+// so tests of optional features should be segregated into separate files.
+message SimpleTestFile {
+  // Required.  The name of the file.  Should match the filename.
+  string name = 1;
+
+  // A description of the file.
+  string description = 2;
+
+  // The contained sections.
+  repeated SimpleTestSection section = 3;
+}
+
+// A collection of related SimpleTests.
+//
+// The section is the unit of organization within a test file, and should
+// guide where new tests are added.
+message SimpleTestSection {
+  // Required.  The name of the section.
+  string name = 1;
+
+  // A description of the section.
+  string description = 2;
+
+  // The contained tests.
+  repeated SimpleTest test = 3;
+}
+
+// A test which should run the given CEL program through parsing,
+// optionally through checking, then evaluation, with the results
+// of the pipeline validated by the given result matcher.
+message SimpleTest {
+  // Required.  The name of the test, which should be unique in the test file.
+  string name = 1;
+
+  // A description of the test.
+  string description = 2;
+
+  // Required.  The text of the CEL expression.
+  string expr = 3;
+
+  // Disables all macro expansion in parsing.
+  bool disable_macros = 4;
+
+  // Disables the check phase.
+  bool disable_check = 5;
+
+  // The type environment to use for the check phase.
+  repeated google.api.expr.v1alpha1.Decl type_env = 6;
+
+  // The container for name resolution.
+  string container = 13;
+
+  // Variable bindings to use for the eval phase.
+  map<string, google.api.expr.v1alpha1.ExprValue> bindings = 7;
+
+  // An unspecified result defaults to a matcher for the true boolean value.
+  oneof result_matcher {
+    // A normal value, which must match the evaluation result exactly
+    // via value equality semantics.  This coincides with proto equality,
+    // except for:
+    // *   maps are order-agnostic.
+    // *   a floating point NaN should match any NaN.
+    google.api.expr.v1alpha1.Value value = 8;
+
+    // Matches error evaluation results.
+    google.api.expr.v1alpha1.ErrorSet eval_error = 9;
+
+    // Matches one of several error results.
+    // (Using explicit message since oneof can't handle repeated.)
+    ErrorSetMatcher any_eval_errors = 10;
+
+    // Matches unknown evaluation results.
+    google.api.expr.v1alpha1.UnknownSet unknown = 11;
+
+    // Matches one of several unknown results.
+    // (Using explicit message since oneof can't handle repeated.)
+    UnknownSetMatcher any_unknowns = 12;
+  }
+  // Next is 14.
+}
+
+// Matches error results from Eval.
+message ErrorSetMatcher {
+  // Success if we match any of these sets.
+  repeated google.api.expr.v1alpha1.ErrorSet errors = 1;
+}
+
+// Matches unknown results from Eval.
+message UnknownSetMatcher {
+  // Success if we match any of these sets.
+  repeated google.api.expr.v1alpha1.UnknownSet unknowns = 1;
+}


### PR DESCRIPTION
For migration purposes reinstate the `proto/test/v1/simple.proto` version
of the conformance test proto.