### PR TITLE
Clarify minimum support for package name length

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -107,7 +107,8 @@ Implementations are required to support at least:
     *   12 nested function calls;
     *   12 selection (`.`) operators in a row;
     *   12 indexing (`[_]`) operators in a row;
-    *   12 nested list, map, or message literals.
+    *   12 nested list, map, or message literals;
+    *   12 (`.`-separated) segments in a protocol buffer package name.
 
 This grammar corresponds to the following operator precedence and associativity:
 


### PR DESCRIPTION
For the benefit of parsers, it's best to clarify how many segments need to be supported in a protocol buffer package name.