### PR TITLE
Fix conformance test spelling mistake varaible -> variable

### DIFF
--- a/tests/simple/testdata/conversions.textproto
+++ b/tests/simple/testdata/conversions.textproto
@@ -306,7 +306,7 @@ section {
     expr: "dyn"
     disable_check: true
     eval_error {
-      errors { message: "unknown varaible" }
+      errors { message: "unknown variable" }
     }
   }
   test {


### PR DESCRIPTION
Just a simple spelling fix. I noticed this because I'm working on implementing the conformance suite for a Ruby implementation and was curious whether it was expected for implementations to check their error messages against the ones in the tests (apparently not or I suspect somebody would have noticed this sooner).