### PR TITLE
Add py_proto_library targets

### DIFF
--- a/proto/cel/expr/BUILD.bazel
+++ b/proto/cel/expr/BUILD.bazel
@@ -229,3 +229,35 @@ cc_proto_library(
     deprecation = "Use EvalState instead.",
     deps = [":explain_proto"],
 )
+
+###############################################################################
+## Python
+###############################################################################
+
+load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
+
+py_proto_library(
+    name = "syntax_py_pb2",
+    deps = [":syntax_proto"],
+)
+
+py_proto_library(
+    name = "checked_py_pb2",
+    deps = [":checked_proto"],
+)
+
+py_proto_library(
+    name = "value_py_pb2",
+    deps = [":value_proto"],
+)
+
+py_proto_library(
+    name = "eval_py_pb2",
+    deps = [":eval_proto"],
+)
+
+py_proto_library(
+    name = "explain_py_pb2",
+    deprecation = "Use EvalState instead.",
+    deps = [":explain_proto"],
+)


### PR DESCRIPTION
This allows using the protos in Python.

Note, in reference to two old, alternative PRs ([PR1](https://github.com/google/cel-spec/pull/318), [PR2](https://github.com/google/cel-spec/pull/325)): To the best of my knowledge, there are (or there used to be) three implementations of `py_proto_library` to choose from, and they don't mix well. The Protobuf team has taken ownership of `py_proto_library` and the implementation from the Protobuf repository is the one to use now.

- The `py_proto_library` from `rules_python` [has been removed](https://github.com/bazel-contrib/rules_python/pull/1933) in favor of the one from Protobuf.
- The `py_proto_library` from gRPC is also deprecated. [gRPC is migrating](https://github.com/grpc/grpc/pull/37866) to the one from Protobuf.