### PR TITLE
Updated testsuite result_kind to use nested ErrorSet

### DIFF
--- a/proto/cel/expr/BUILD.bazel
+++ b/proto/cel/expr/BUILD.bazel
@@ -70,7 +70,7 @@ proto_library(
     strip_import_prefix = "/proto",
     deps = [
         ":value_proto",
-        "@com_google_googleapis//google/rpc:status_proto",
+        "@com_google_protobuf//:any_proto",
     ],
 )
 

--- a/proto/cel/expr/conformance/test/suite.proto
+++ b/proto/cel/expr/conformance/test/suite.proto
@@ -148,38 +148,9 @@ message TestOutput {
 
     // An error evaluation result set. Success if we match all of the errors in
     // the set.
-    ErrorSet eval_error = 10;
+    cel.expr.ErrorSet eval_error = 10;
 
     // An unknown evaluation result.
     cel.expr.UnknownSet unknown = 11;
-  }
-
-  // A set of errors.
-  //
-  // The errors included depend on the context. See `ExprValue.error`.
-  message ErrorSet {
-    repeated Status errors = 1;
-  }
-
-  // The `Status` type defines a logical error model that is suitable for
-  // different programming environments, including REST APIs and RPC APIs. It is
-  // used by [gRPC](https://github.com/grpc). Each `Status` message contains
-  // three pieces of data: error code, error message, and error details.
-  //
-  // You can find out more about this error model and how to work with it in the
-  // [API Design Guide](https://cloud.google.com/apis/design/errors).
-  //
-  message Status {
-    // The status code, which should be an enum value of [google.rpc.Code][].
-    int32 code = 1;
-
-    // A developer-facing error message, which should be in English. Any
-    // user-facing error message should be localized and sent in the
-    // [google.rpc.Status.details][] field, or localized by the client.
-    string message = 2;
-
-    // A list of messages that carry the error details.  There is a common set of
-    // message types for APIs to use.
-    repeated google.protobuf.Any details = 3;
   }
 }

--- a/proto/cel/expr/conformance/test/suite.proto
+++ b/proto/cel/expr/conformance/test/suite.proto
@@ -148,9 +148,38 @@ message TestOutput {
 
     // An error evaluation result set. Success if we match all of the errors in
     // the set.
-    cel.expr.ErrorSet eval_error = 10;
+    ErrorSet eval_error = 10;
 
     // An unknown evaluation result.
     cel.expr.UnknownSet unknown = 11;
+  }
+
+  // A set of errors.
+  //
+  // The errors included depend on the context. See `ExprValue.error`.
+  message ErrorSet {
+    repeated Status errors = 1;
+  }
+
+  // The `Status` type defines a logical error model that is suitable for
+  // different programming environments, including REST APIs and RPC APIs. It is
+  // used by [gRPC](https://github.com/grpc). Each `Status` message contains
+  // three pieces of data: error code, error message, and error details.
+  //
+  // You can find out more about this error model and how to work with it in the
+  // [API Design Guide](https://cloud.google.com/apis/design/errors).
+  //
+  message Status {
+    // The status code, which should be an enum value of [google.rpc.Code][].
+    int32 code = 1;
+
+    // A developer-facing error message, which should be in English. Any
+    // user-facing error message should be localized and sent in the
+    // [google.rpc.Status.details][] field, or localized by the client.
+    string message = 2;
+
+    // A list of messages that carry the error details.  There is a common set of
+    // message types for APIs to use.
+    repeated google.protobuf.Any details = 3;
   }
 }

--- a/proto/cel/expr/eval.proto
+++ b/proto/cel/expr/eval.proto
@@ -108,21 +108,20 @@ message ErrorSet {
   repeated Status errors = 1;
 }
 
-  // The `Status` type defines a logical error model that is suitable for
-  // different programming environments, including REST APIs and RPC APIs. It is
-  // used by [gRPC](https://github.com/grpc). Each `Status` message contains
-  // three pieces of data: error code, error message, and error details.
+  // Each `Status` message contains three pieces of data: error code, error message,
+  // and error details.
   //
   // You can find out more about this error model and how to work with it in the
   // [API Design Guide](https://cloud.google.com/apis/design/errors).
   //
+  // Status value is intended to be wire and field compatible with `google.rpc.Status`.
   message Status {
     // The status code, which should be an enum value of [google.rpc.Code][].
     int32 code = 1;
 
     // A developer-facing error message, which should be in English. Any
     // user-facing error message should be localized and sent in the
-    // [google.rpc.Status.details][] field, or localized by the client.
+    // [Status.details][] field, or localized by the client.
     string message = 2;
 
     // A list of messages that carry the error details.  There is a common set of

--- a/proto/cel/expr/eval.proto
+++ b/proto/cel/expr/eval.proto
@@ -16,8 +16,8 @@ syntax = "proto3";
 
 package cel.expr;
 
+import "google/protobuf/any.proto";
 import "cel/expr/value.proto";
-import "google/rpc/status.proto";
 
 option cc_enable_arenas = true;
 option go_package = "cel.dev/expr";
@@ -104,8 +104,31 @@ message ExprValue {
 //
 // The errors included depend on the context. See `ExprValue.error`.
 message ErrorSet {
-  repeated google.rpc.Status errors = 1;
+  // Errors that could come up during evaluation phase.
+  repeated Status errors = 1;
 }
+
+  // The `Status` type defines a logical error model that is suitable for
+  // different programming environments, including REST APIs and RPC APIs. It is
+  // used by [gRPC](https://github.com/grpc). Each `Status` message contains
+  // three pieces of data: error code, error message, and error details.
+  //
+  // You can find out more about this error model and how to work with it in the
+  // [API Design Guide](https://cloud.google.com/apis/design/errors).
+  //
+  message Status {
+    // The status code, which should be an enum value of [google.rpc.Code][].
+    int32 code = 1;
+
+    // A developer-facing error message, which should be in English. Any
+    // user-facing error message should be localized and sent in the
+    // [google.rpc.Status.details][] field, or localized by the client.
+    string message = 2;
+
+    // A list of messages that carry the error details.  There is a common set of
+    // message types for APIs to use.
+    repeated google.protobuf.Any details = 3;
+  }
 
 // A set of expressions for which the value is unknown.
 //


### PR DESCRIPTION
Updated testsuite result_kind to use nested ErrorSet and remove dependency from cel.expr.ErrorSet since in Java this causes classpath conflict when adding com.google.api.grpc:proto-google-common-protos.