### PR TITLE
Add tests for invalid utf8 when formatting

### DIFF
--- a/tests/simple/testdata/string_ext.textproto
+++ b/tests/simple/testdata/string_ext.textproto
@@ -633,6 +633,20 @@ section: {
     }
   }
   test: {
+    name: "bytes support for string with invalid utf-8 sequences"
+    expr: '"%s".format([b"\xF0abc\x8Cxyz"])'
+    value: {
+      string_value: '\ufffdabc\ufffdxyz',
+    }
+  }
+  test: {
+    name: "bytes support for string with multiple adjacent invalid utf-8 sequences"
+    expr: '"%s".format([b"\xF0\x8C\xF0"])'
+    value: {
+      string_value: '\ufffd',
+    }
+  }
+  test: {
     name: "type() support for string"
     expr: '"%s".format([type("test string")])'
     value: {

--- a/tests/simple/testdata/string_ext.textproto
+++ b/tests/simple/testdata/string_ext.textproto
@@ -634,13 +634,13 @@ section: {
   }
   test: {
     name: "bytes support for string with invalid utf-8 sequences"
-    expr: '"%s".format([b"\xF0abc\x8Cxyz"])'
+    expr: '"%s".format([b"\xF0abc\x8C\xF0xyz"])'
     value: {
       string_value: '\ufffdabc\ufffdxyz',
     }
   }
   test: {
-    name: "bytes support for string with multiple adjacent invalid utf-8 sequences"
+    name: "bytes support for string with only invalid utf-8 sequences"
     expr: '"%s".format([b"\xF0\x8C\xF0"])'
     value: {
       string_value: '\ufffd',


### PR DESCRIPTION
According to docs:

> The value is formatted as if string(value)was performed and any invalid UTF-8 sequences are replaced with \ufffd. Multiple adjacent invalid UTF-8 sequences must be replaced with a single `\ufffd`.

This adds two additional tests to verify:
* invalid UTF-8 sequences are each replaced with `\ufffd`.
* multiple adjacent invalid UTF-8 sequences are replaced with a single `/ufffd`.