### PR TITLE
Remove orphaned ToC entry for enums as ints from the specification

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -958,7 +958,7 @@ computation. Argument and result types can use type variables to express
 overloads which work on lists and maps. At runtime, a matching overload is
 selected and the according computation invoked. If no overload matches, the
 runtime error `no_matching_overload` is raised (see also
-[Runtime Errors](#errors)). For example, the standard function `size` is
+[Runtime Errors](#runtime-errors)). For example, the standard function `size` is
 specified by the following overloads:
 
 <table border="1">


### PR DESCRIPTION
The section was removed in https://github.com/google/cel-spec/pull/321.

This also fixes a link to the "Runtime Errors" section.