### PR TITLE
add missing expected assertion value to math ext conformance tests

### DIFF
--- a/tests/simple/testdata/math_ext.textproto
+++ b/tests/simple/testdata/math_ext.textproto
@@ -28,11 +28,17 @@ section: {
   }
   test: {
     name: "binary_with_decimal"
-    expr: "math.greatest(1, 1.0) == 1"
+    expr: "math.greatest(1, 1.0) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_with_uint"
-    expr: "math.greatest(1, 1u) == 1"
+    expr: "math.greatest(1, 1u) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_first_arg_greater"
@@ -78,47 +84,80 @@ section: {
   }
   test: {
     name: "ternary_same_args"
-    expr: "math.greatest(1, 1, 1) == 1"
+    expr: "math.greatest(1, 1, 1) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_decimal"
-    expr: "math.greatest(1, 1.0, 1.0) == 1"
+    expr: "math.greatest(1, 1.0, 1.0) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_uint"
-    expr: "math.greatest(1, 1u, 1u) == 1"
+    expr: "math.greatest(1, 1u, 1u) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_first_arg_greatest"
-    expr: "math.greatest(10, 1, 3) == 10"
+    expr: "math.greatest(10, 1, 3) == 10",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_third_arg_greatest"
-    expr: "math.greatest(1, 3, 10) == 10"
+    expr: "math.greatest(1, 3, 10) == 10",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_negatives"
-    expr: "math.greatest(-1, -2, -3) == -1"
+    expr: "math.greatest(-1, -2, -3) == -1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_int_max"
-    expr: "math.greatest(9223372036854775807, 1, 5) == 9223372036854775807"
+    expr: "math.greatest(9223372036854775807, 1, 5) == 9223372036854775807",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_int_min"
-    expr: "math.greatest(-9223372036854775807, -1, -5) == -1"
+    expr: "math.greatest(-9223372036854775807, -1, -5) == -1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed"
-    expr: "math.greatest(5.4, 10, 3u, -5.0, 9223372036854775807) == 9223372036854775807"
+    expr: "math.greatest(5.4, 10, 3u, -5.0, 9223372036854775807) == 9223372036854775807",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_array"
-    expr: "math.greatest([5.4, 10, 3u, -5.0, 3.5]) == 10"
+    expr: "math.greatest([5.4, 10, 3u, -5.0, 3.5]) == 10",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_dyn_array"
-    expr: "math.greatest([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10"
+    expr: "math.greatest([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10",
+    value: {
+      bool_value: true
+    }
   }
 }
 
@@ -147,11 +186,17 @@ section: {
   }
   test: {
     name: "binary_with_int"
-    expr: "math.greatest(1.0, 1) == 1.0"
+    expr: "math.greatest(1.0, 1) == 1.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_with_uint"
-    expr: "math.greatest(1.0, 1u) == 1.0"
+    expr: "math.greatest(1.0, 1u) == 1.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_first_arg_greater"
@@ -197,47 +242,80 @@ section: {
   }
   test: {
     name: "ternary_same_args"
-    expr: "math.greatest(1.0, 1.0, 1.0) == 1.0"
+    expr: "math.greatest(1.0, 1.0, 1.0) == 1.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_int"
-    expr: "math.greatest(1.0, 1, 1) == 1.0"
+    expr: "math.greatest(1.0, 1, 1) == 1.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_uint"
-    expr: "math.greatest(1.0, 1u, 1u) == 1.0"
+    expr: "math.greatest(1.0, 1u, 1u) == 1.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_first_arg_greatest"
-    expr: "math.greatest(10.5, 1.5, 3.5) == 10.5"
+    expr: "math.greatest(10.5, 1.5, 3.5) == 10.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_third_arg_greatest"
-    expr: "math.greatest(1.5, 3.5, 10.5) == 10.5"
+    expr: "math.greatest(1.5, 3.5, 10.5) == 10.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_negatives"
-    expr: "math.greatest(-1.5, -2.5, -3.5) == -1.5"
+    expr: "math.greatest(-1.5, -2.5, -3.5) == -1.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_double_max"
-    expr: "math.greatest(1.797693e308, 1, 5) == 1.797693e308"
+    expr: "math.greatest(1.797693e308, 1, 5) == 1.797693e308",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_double_min"
-    expr: "math.greatest(-1.797693e308, -1, -5) == -1"
+    expr: "math.greatest(-1.797693e308, -1, -5) == -1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed"
-    expr: "math.greatest(5.4, 10, 3u, -5.0, 1.797693e308) == 1.797693e308"
+    expr: "math.greatest(5.4, 10, 3u, -5.0, 1.797693e308) == 1.797693e308",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_array"
-    expr: "math.greatest([5.4, 10.5, 3u, -5.0, 3.5]) == 10.5"
+    expr: "math.greatest([5.4, 10.5, 3u, -5.0, 3.5]) == 10.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_dyn_array"
-    expr: "math.greatest([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10.5"
+    expr: "math.greatest([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10.5",
+    value: {
+      bool_value: true
+    }
   }
 }
 
@@ -259,11 +337,17 @@ section: {
   }
   test: {
     name: "binary_with_decimal"
-    expr: "math.greatest(1u, 1.0) == 1"
+    expr: "math.greatest(1u, 1.0) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_with_int"
-    expr: "math.greatest(1u, 1) == 1u"
+    expr: "math.greatest(1u, 1) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_first_arg_greater"
@@ -295,39 +379,66 @@ section: {
   }
   test: {
     name: "ternary_same_args"
-    expr: "math.greatest(1u, 1u, 1u) == 1u"
+    expr: "math.greatest(1u, 1u, 1u) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_decimal"
-    expr: "math.greatest(1u, 1.0, 1.0) == 1u"
+    expr: "math.greatest(1u, 1.0, 1.0) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_int"
-    expr: "math.greatest(1u, 1, 1) == 1u"
+    expr: "math.greatest(1u, 1, 1) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_first_arg_greatest"
-    expr: "math.greatest(10u, 1u, 3u) == 10u"
+    expr: "math.greatest(10u, 1u, 3u) == 10u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_third_arg_greatest"
-    expr: "math.greatest(1u, 3u, 10u) == 10u"
+    expr: "math.greatest(1u, 3u, 10u) == 10u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_int_max"
-    expr: "math.greatest(18446744073709551615u, 1u, 5u) == 18446744073709551615u"
+    expr: "math.greatest(18446744073709551615u, 1u, 5u) == 18446744073709551615u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed"
-    expr: "math.greatest(5.4, 10, 3u, -5.0, 18446744073709551615u) == 18446744073709551615u"
+    expr: "math.greatest(5.4, 10, 3u, -5.0, 18446744073709551615u) == 18446744073709551615u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_array"
-    expr: "math.greatest([5.4, 10u, 3u, -5.0, 3.5]) == 10u"
+    expr: "math.greatest([5.4, 10u, 3u, -5.0, 3.5]) == 10u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_dyn_array"
-    expr: "math.greatest([dyn(5.4), dyn(10u), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10u"
+    expr: "math.greatest([dyn(5.4), dyn(10u), dyn(3u), dyn(-5.0), dyn(3.5)]) == 10u",
+    value: {
+      bool_value: true
+    }
   }
 }
 
@@ -356,11 +467,17 @@ section: {
   }
   test: {
     name: "binary_with_decimal"
-    expr: "math.least(1, 1.0) == 1"
+    expr: "math.least(1, 1.0) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_with_uint"
-    expr: "math.least(1, 1u) == 1"
+    expr: "math.least(1, 1u) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_first_arg_least"
@@ -406,47 +523,80 @@ section: {
   }
   test: {
     name: "ternary_same_args"
-    expr: "math.least(1, 1, 1) == 1"
+    expr: "math.least(1, 1, 1) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_decimal"
-    expr: "math.least(1, 1.0, 1.0) == 1"
+    expr: "math.least(1, 1.0, 1.0) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_uint"
-    expr: "math.least(1, 1u, 1u) == 1"
+    expr: "math.least(1, 1u, 1u) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_first_arg_least"
-    expr: "math.least(0, 1, 3) == 0"
+    expr: "math.least(0, 1, 3) == 0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_third_arg_least"
-    expr: "math.least(1, 3, 0) == 0"
+    expr: "math.least(1, 3, 0) == 0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_negatives"
-    expr: "math.least(-1, -2, -3) == -3"
+    expr: "math.least(-1, -2, -3) == -3",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_int_max"
-    expr: "math.least(9223372036854775807, 1, 5) == 1"
+    expr: "math.least(9223372036854775807, 1, 5) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_int_min"
-    expr: "math.least(-9223372036854775808, -1, -5) == -9223372036854775808"
+    expr: "math.least(-9223372036854775808, -1, -5) == -9223372036854775808",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed"
-    expr: "math.least(5.4, 10, 3u, -5.0, 9223372036854775807) == -5.0"
+    expr: "math.least(5.4, 10, 3u, -5.0, 9223372036854775807) == -5.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_array"
-    expr: "math.least([5.4, 10, 3u, -5.0, 3.5]) == -5.0"
+    expr: "math.least([5.4, 10, 3u, -5.0, 3.5]) == -5.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_dyn_array"
-    expr: "math.least([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0"
+    expr: "math.least([dyn(5.4), dyn(10), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0",
+    value: {
+      bool_value: true
+    }
   }
 }
 
@@ -475,11 +625,17 @@ section: {
   }
   test: {
     name: "binary_with_int"
-    expr: "math.least(1.0, 1) == 1"
+    expr: "math.least(1.0, 1) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_with_uint"
-    expr: "math.least(1, 1u) == 1"
+    expr: "math.least(1, 1u) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_first_arg_least"
@@ -525,47 +681,80 @@ section: {
   }
   test: {
     name: "ternary_same_args"
-    expr: "math.least(1.5, 1.5, 1.5) == 1.5"
+    expr: "math.least(1.5, 1.5, 1.5) == 1.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_int"
-    expr: "math.least(1.0, 1, 1) == 1.0"
+    expr: "math.least(1.0, 1, 1) == 1.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_uint"
-    expr: "math.least(1.0, 1u, 1u) == 1"
+    expr: "math.least(1.0, 1u, 1u) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_first_arg_least"
-    expr: "math.least(0.5, 1.5, 3.5) == 0.5"
+    expr: "math.least(0.5, 1.5, 3.5) == 0.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_third_arg_least"
-    expr: "math.least(1.5, 3.5, 0.5) == 0.5"
+    expr: "math.least(1.5, 3.5, 0.5) == 0.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_negatives"
-    expr: "math.least(-1.5, -2.5, -3.5) == -3.5"
+    expr: "math.least(-1.5, -2.5, -3.5) == -3.5",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_double_max"
-    expr: "math.least(1.797693e308, 1, 5) == 1"
+    expr: "math.least(1.797693e308, 1, 5) == 1",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_double_min"
-    expr: "math.least(-1.797693e308, -1, -5) == -1.797693e308"
+    expr: "math.least(-1.797693e308, -1, -5) == -1.797693e308",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed"
-    expr: "math.least(5.4, 10, 3u, -5.0, 1.797693e308) == -5.0"
+    expr: "math.least(5.4, 10, 3u, -5.0, 1.797693e308) == -5.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_array"
-    expr: "math.least([5.4, 10.5, 3u, -5.0, 3.5]) == -5.0"
+    expr: "math.least([5.4, 10.5, 3u, -5.0, 3.5]) == -5.0",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_dyn_array"
-    expr: "math.least([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0"
+    expr: "math.least([dyn(5.4), dyn(10.5), dyn(3u), dyn(-5.0), dyn(3.5)]) == -5.0",
+    value: {
+      bool_value: true
+    }
   }
 }
 
@@ -587,11 +776,17 @@ section: {
   }
   test: {
     name: "binary_with_decimal"
-    expr: "math.least(1u, 1.0) == 1u"
+    expr: "math.least(1u, 1.0) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_with_int"
-    expr: "math.least(1u, 1) == 1u"
+    expr: "math.least(1u, 1) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "binary_first_arg_least"
@@ -623,39 +818,66 @@ section: {
   }
   test: {
     name: "ternary_same_args"
-    expr: "math.least(1u, 1u, 1u) == 1u"
+    expr: "math.least(1u, 1u, 1u) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_decimal"
-    expr: "math.least(1u, 1.0, 1.0) == 1u"
+    expr: "math.least(1u, 1.0, 1.0) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_with_int"
-    expr: "math.least(1u, 1, 1) == 1u"
+    expr: "math.least(1u, 1, 1) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_first_arg_least"
-    expr: "math.least(1u, 10u, 3u) == 1u"
+    expr: "math.least(1u, 10u, 3u) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_third_arg_least"
-    expr: "math.least(10u, 3u, 1u) == 1u"
+    expr: "math.least(10u, 3u, 1u) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "ternary_uint_max"
-    expr: "math.least(18446744073709551615u, 1u, 5u) == 1u"
+    expr: "math.least(18446744073709551615u, 1u, 5u) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed"
-    expr: "math.least(5.4, 10, 3u, 1u, 18446744073709551615u) == 1u"
+    expr: "math.least(5.4, 10, 3u, 1u, 18446744073709551615u) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_array"
-    expr: "math.least([5.4, 10u, 3u, 1u, 3.5]) == 1u"
+    expr: "math.least([5.4, 10u, 3u, 1u, 3.5]) == 1u",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "quaternary_mixed_dyn_array"
-    expr: "math.least([dyn(5.4), dyn(10u), dyn(3u), dyn(1u), dyn(3.5)]) == 1u"
+    expr: "math.least([dyn(5.4), dyn(10u), dyn(3u), dyn(1u), dyn(3.5)]) == 1u",
+    value: {
+      bool_value: true
+    }
   }
 }
 
@@ -752,7 +974,10 @@ section: {
   }
   test: {
     name: "nan"
-    expr: "math.isNaN(math.round(0.0/0.0))"
+    expr: "math.isNaN(math.round(0.0/0.0))",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "dyn_error"
@@ -783,7 +1008,10 @@ section: {
   }
   test: {
     name: "nan"
-    expr: "math.isNaN(math.trunc(0.0/0.0))"
+    expr: "math.isNaN(math.trunc(0.0/0.0))",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "dyn_error"
@@ -938,11 +1166,17 @@ section: {
   name: "isInf"
   test: {
     name: "true"
-    expr: "math.isInf(1.0/0.0)"
+    expr: "math.isInf(1.0/0.0)",
+    value: {
+      bool_value: true
+    }
   }
    test: {
     name: "false"
-    expr: "!math.isInf(0.0/0.0)"
+    expr: "!math.isInf(0.0/0.0)",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "dyn_error"
@@ -959,15 +1193,24 @@ section: {
   name: "isFinite"
   test: {
     name: "true"
-    expr: "math.isFinite(1.0/1.5)"
+    expr: "math.isFinite(1.0/1.5)",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "false_nan"
-    expr: "!math.isFinite(0.0/0.0)"
+    expr: "!math.isFinite(0.0/0.0)",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "false_inf"
-    expr: "!math.isFinite(-1.0/0.0)"
+    expr: "!math.isFinite(-1.0/0.0)",
+    value: {
+      bool_value: true
+    }
   }
   test: {
     name: "dyn_error"


### PR DESCRIPTION
they seem to be implicitly falling back to the boolean evaluation, but it's better to be explicit to avoid confusion with type-only assertions and other exceptional logic