### PR TITLE
Remove int(enum) -> int signature

### DIFF
--- a/doc/langdef.md
+++ b/doc/langdef.md
@@ -2147,7 +2147,6 @@ dyn("hello") // string "hello" marked `dyn` during type-checking
 *   `int(double) -> int` (type conversion, rounds toward zero, errors if out of
     range)
 *   `int(string) -> int` (type conversion)
-*   `int(enum E) -> int` (type conversion)
 *   `int(google.protobuf.Timestamp) -> int` converts to seconds since Unix
     epoch
 


### PR DESCRIPTION
CEL doesn't have an enum type and conversion of protobuf enums to ints is covered elsewhere.