### PR TITLE
Add Java and C++ proto library loading

### DIFF
--- a/proto/cel/expr/BUILD.bazel
+++ b/proto/cel/expr/BUILD.bazel
@@ -5,6 +5,8 @@ package(default_visibility = ["//visibility:public"])
 ##############################################################################
 
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 
 proto_library(
     name = "expr_proto",


### PR DESCRIPTION
This is needed to fix building grpc with Bazel 9