### PR TITLE
Add basic tests for out-of-range epoch int to timestamp conversions

### DIFF
--- a/tests/simple/testdata/timestamps.textproto
+++ b/tests/simple/testdata/timestamps.textproto
@@ -381,8 +381,22 @@ section {
     }
   }
   test {
+    name: "from_int_under"
+    expr: "timestamp(-62135596801)"
+    eval_error {
+      errors { message: "range" }
+    }
+  }
+  test {
     name: "from_string_over"
     expr: "timestamp('10000-01-01T00:00:00Z')"
+    eval_error {
+      errors { message: "range" }
+    }
+  }
+  test {
+    name: "from_int_over"
+    expr: "timestamp(253402300800)"
     eval_error {
       errors { message: "range" }
     }


### PR DESCRIPTION
The epoch values correspond to:

timestamp(-62135596801) -> 0000-12-31T23:59:59Z
timestamp(253402300800) -> 10000-01-01T00:00:00Z