### PR TITLE
Disallow timestamp field values outside RFC 3339 range

### DIFF
--- a/tests/simple/testdata/wrappers.textproto
+++ b/tests/simple/testdata/wrappers.textproto
@@ -358,6 +358,22 @@ section {
       string_value: "9999-12-31T23:59:59.999999999Z"
     }
   }
+  test {
+    name: "timestamp_out_of_range_max"
+    container: "cel.expr.conformance.proto3"
+    expr: "TestAllTypes{single_timestamp: google.protobuf.Timestamp{ seconds: 253402300800 } }"
+    eval_error: {
+      errors: { message: "range" }
+    }
+  }
+  test {
+    name: "timestamp_out_of_range_min"
+    container: "cel.expr.conformance.proto3"
+    expr: "TestAllTypes{single_timestamp: google.protobuf.Timestamp{ seconds: -62135596801 } }"
+    eval_error: {
+      errors: { message: "range" }
+    }
+  }
 }
 
 # google.protobuf.Empty


### PR DESCRIPTION
xref: https://github.com/google/cel-java/issues/890

CEL enforces the RFC 3339 timestamp range (0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z).

Currently, explicit conversions enforce these bounds correctly. However, Protobuf message field values are an exception; they bypass this validation, allowing timestamps outside the valid range to enter the evaluation context.

`google.protobuf.Timestamp{ seconds: -62135596801 }` -> `timestamp("0000-12-31T23:59:59Z")`

Ingesting a Protobuf message with an out-of-range timestamp (e.g., seconds: -62135596801) results in a valid CEL timestamp object, but subsequent operations lead to inconsistent or undefined behavior:

```
google.protobuf.Timestamp{ seconds: -62135596801 } - timestamp(0) -> error
google.protobuf.Timestamp{ seconds: 253402300800} + duration("0") -> error
string(google.protobuf.Timestamp{ seconds: 253402300800}) -> error in C++/Java, produces timestamp("10000-01-01T00:00:00Z") in go (Special note that this expression is not round-trippable)
```