### PR TITLE
Lint fixes for import

### DIFF
--- a/tests/simple/testdata/network_ext.textproto
+++ b/tests/simple/testdata/network_ext.textproto
@@ -10,7 +10,7 @@ section {
     name: "parse_ipv4"
     description: "Successfully parse a standard IPv4 address"
     expr: "string(ip('192.168.0.1'))"
-    value: { string_value: "192.168.0.1" }  
+    value: { string_value: "192.168.0.1" }
   }
   test {
     name: "parse_invalid_ipv4"
@@ -320,7 +320,7 @@ section {
     name: "cidr_does_not_contain_ip_ipv4_string"
     expr: "cidr('192.168.0.0/24').containsIP('192.168.1.1')"
     value: { bool_value: false }
-  }  
+  }
   test {
     name: "cidr_contains_cidr_ipv4_object"
     expr: "cidr('192.168.0.0/24').containsCIDR(cidr('192.168.0.0/25'))"

--- a/tests/simple/testdata/parse.textproto
+++ b/tests/simple/testdata/parse.textproto
@@ -120,7 +120,7 @@ section {
     name: "map_literal"
     description: "Primary = '{' [MapInits] '}'. Map literals with up to 32 entries."
     expr: "{0: 'zero', 1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five', 6: 'six', 7: 'seven', 8: 'eight', 9: 'nine', 10: 'ten', 11: 'eleven', 12: 'twelve', 13: 'thirteen', 14: 'fourteen', 15: 'fifteen', 16: 'sixteen', 17: 'seventeen', 18: 'eighteen', 19: 'nineteen', 20: 'twenty', 21: 'twenty-one', 22: 'twenty-two', 23: 'twenty-three', 24: 'twenty-four', 25: 'twenty-five', 26: 'twenty-six', 27: 'twenty-seven', 28: 'twenty-eight', 29: 'twenty-nine', 30: 'thirty', 31: 'thirty-one'}[17]"
-    value { string_value: 'seventeen' }
+    value { string_value: "seventeen" }
   }
   test {
     name: "message_literal"
@@ -130,6 +130,8 @@ section {
     value { int64_value: 30 }
   }
 }
+
+# txtpbfmt: off
 section {
   name: "string_literals"
   description: "Check that string literals are properly parsed"
@@ -944,6 +946,8 @@ section {
     value: { bytes_value: " \\\\ \\? \\\" \\\' \\` \\a \\b \\f \\t \\v \\n \\r \\000 \\x00 \\X00 \\u0000 \\U00000000 " }
   }
 }
+# txtpbfmt: on
+
 section {
   name: "whitespace"
   description: "Check that whitespace is ignored by the grammar."


### PR DESCRIPTION
Disable formatter for string literal section to mix single / double quote textproto strings for readability.